### PR TITLE
Haxe global

### DIFF
--- a/haxelib.json
+++ b/haxelib.json
@@ -5,7 +5,7 @@
 	"description": "Haxe-JS code-splitting and hot-reload for modular applications",
 	"contributors": ["elsassph"],
 	"releasenote": "See https://github.com/elsassph/haxe-modular",
-	"version": "0.1.2",
+	"version": "0.1.3",
 	"url": "https://github.com/elsassph/haxe-modular",
 	"classPath": "src",
 	"dependencies": {}

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "haxe-modular",
-  "version": "0.1.2",
+  "version": "0.1.3",
   "description": "",
   "main": "runtime/index.js",
   "bin": {

--- a/tool/bin/split.js
+++ b/tool/bin/split.js
@@ -101,7 +101,7 @@ Bundler.prototype = {
 			buffer += HxOverrides.substr(src,run.start,run.end - run.start);
 			buffer += "\n";
 		}
-		buffer += "})(typeof $hx_scope != \"undefined\" ? $hx_scope : $hx_scope = {});\n";
+		buffer += "})(" + "typeof $hx_scope != \"undefined\" ? $hx_scope : $hx_scope = {}" + ", " + "typeof window != \"undefined\" ? window : typeof global != \"undefined\" ? global : typeof self != \"undefined\" ? self : this" + ");\n";
 		return { src : buffer, map : this.sourceMap.emitMappings(mapNodes,mapOffset)};
 	}
 	,emitHot: function(inc) {
@@ -116,10 +116,10 @@ Bundler.prototype = {
 		if(names.length == 0) {
 			return "";
 		}
-		return "if (window.__REACT_HOT_LOADER__)\n" + ("  [" + names.join(",") + "].map(function(name) {\n") + "    __REACT_HOT_LOADER__.register(name,name.displayName,name.__fileName__);\n" + "  });\n";
+		return "if ($" + "global.__REACT_HOT_LOADER__)\n" + ("  [" + names.join(",") + "].map(function(name) {\n") + "    __REACT_HOT_LOADER__.register(name,name.displayName,name.__fileName__);\n" + "  });\n";
 	}
 	,verifyExport: function(s) {
-		return s.replace(new RegExp("function \\([^)]*\\)","".split("u").join("")),"function ($" + "hx_exports)");
+		return s.replace(new RegExp("function \\([^)]*\\)","".split("u").join("")),"function ($hx_exports, $global)");
 	}
 	,process: function(modules) {
 		console.log("Bundling...");
@@ -906,7 +906,10 @@ Date.__name__ = ["Date"];
 var __map_reserved = {}
 Bundler.REQUIRE = "var require = (function(r){ return function require(m) { return r[m]; } })($hx_exports.__registry__);\n";
 Bundler.SHARED = "var $s = $hx_exports.__shared__ = $hx_exports.__shared__ || {};\n";
-Bundler.SCOPE = "})(typeof $hx_scope != \"undefined\" ? $hx_scope : $hx_scope = {});\n";
+Bundler.SCOPE = "typeof $hx_scope != \"undefined\" ? $hx_scope : $hx_scope = {}";
+Bundler.GLOBAL = "typeof window != \"undefined\" ? window : typeof global != \"undefined\" ? global : typeof self != \"undefined\" ? self : this";
+Bundler.ARGS = "})(" + "typeof $hx_scope != \"undefined\" ? $hx_scope : $hx_scope = {}" + ", " + "typeof window != \"undefined\" ? window : typeof global != \"undefined\" ? global : typeof self != \"undefined\" ? self : this" + ");\n";
+Bundler.FUNCTION = "function ($hx_exports, $global)";
 SourceMap.SRC_REF = "//# sourceMappingURL=";
 Main.main();
 })();

--- a/tool/src/Bundler.hx
+++ b/tool/src/Bundler.hx
@@ -19,7 +19,10 @@ class Bundler
 {
 	static inline var REQUIRE = "var require = (function(r){ return function require(m) { return r[m]; } })($hx_exports.__registry__);\n";
 	static inline var SHARED = "var $s = $hx_exports.__shared__ = $hx_exports.__shared__ || {};\n";
-	static inline var SCOPE = "})(typeof $hx_scope != \"undefined\" ? $hx_scope : $hx_scope = {});\n";
+	static inline var SCOPE = "typeof $hx_scope != \"undefined\" ? $hx_scope : $hx_scope = {}";
+	static inline var GLOBAL = "typeof window != \"undefined\" ? window : typeof global != \"undefined\" ? global : typeof self != \"undefined\" ? self : this";
+	static inline var ARGS = '})($SCOPE, $GLOBAL);\n';
+	static inline var FUNCTION = "function ($hx_exports, $global)";
 
 	var parser:Parser;
 	var sourceMap:SourceMap;
@@ -125,7 +128,7 @@ class Bundler
 			buffer += '\n';
 		}
 		
-		buffer += SCOPE;
+		buffer += ARGS;
 		return {
 			src:buffer,
 			map:sourceMap.emitMappings(mapNodes, mapOffset)
@@ -140,7 +143,7 @@ class Bundler
 		
 		if (names.length == 0) return '';
 
-		return 'if (window.__REACT_HOT_LOADER__)\n'
+		return 'if ($$global.__REACT_HOT_LOADER__)\n'
 			+ '  [${names.join(",")}].map(function(name) {\n'
 			+ '    __REACT_HOT_LOADER__.register(name,name.displayName,name.__fileName__);\n'
 			+ '  });\n';
@@ -148,7 +151,7 @@ class Bundler
 	
 	function verifyExport(s:String) 
 	{
-		return ~/function \([^)]*\)/.replace(s, 'function ($$hx_exports)');
+		return ~/function \([^)]*\)/.replace(s, FUNCTION);
 	}
 	
 	public function process(modules:Array<String>) 


### PR DESCRIPTION
Haxe JS sometimes emits code using `$global` as system-dependent scope (`window` in browser, `global` for nodejs...). This global scope is resolved and passed to the closure.