### PR TITLE
Hoist enums in main bundle

### DIFF
--- a/tool/bin/split.js
+++ b/tool/bin/split.js
@@ -131,6 +131,8 @@ Bundler.prototype = {
 			this.unlink(g,$module);
 		}
 		var mainNodes = graphlib_Alg.preorder(g,"Main");
+		var tmp = this.parser.isEnum.keys();
+		while(tmp.hasNext()) mainNodes.push(tmp.next());
 		var exports = [];
 		var _g1 = 0;
 		while(_g1 < modules.length) {
@@ -339,6 +341,7 @@ Parser.prototype = {
 		this.init = new haxe_ds_StringMap();
 		this.requires = new haxe_ds_StringMap();
 		this.isHot = new haxe_ds_StringMap();
+		this.isEnum = new haxe_ds_StringMap();
 		this.step = ParseStep.Start;
 		var body = this.getBodyNodes(program);
 		var _g = 0;
@@ -523,14 +526,20 @@ Parser.prototype = {
 						}
 						break;
 					case "ObjectExpression":
-						if(this.isEnum(init)) {
+						if(this.isEnumDecl(init)) {
+							var _this2 = this.isEnum;
+							if(__map_reserved[name] != null) {
+								_this2.setReserved(name,true);
+							} else {
+								_this2.h[name] = true;
+							}
 							this.register(name,def);
 						} else {
-							var _this2 = this.candidates;
+							var _this3 = this.candidates;
 							if(__map_reserved[name] != null) {
-								_this2.setReserved(name,def);
+								_this3.setReserved(name,def);
 							} else {
-								_this2.h[name] = def;
+								_this3.h[name] = def;
 							}
 						}
 						break;
@@ -606,7 +615,7 @@ Parser.prototype = {
 		}
 		defs.push(def);
 	}
-	,isEnum: function(node) {
+	,isEnumDecl: function(node) {
 		var props = node.properties;
 		if(node.type == "ObjectExpression" && props != null && props.length > 0) {
 			return this.getIdentifier(props[0].key)[0] == "__ename__";

--- a/tool/src/Bundler.hx
+++ b/tool/src/Bundler.hx
@@ -165,9 +165,11 @@ class Bundler
 		
 		// find main nodes
 		var mainNodes = Alg.preorder(g, 'Main');
-		var exports = [];
+		// hoist enums in main module to avoid conflicts
+		for (key in parser.isEnum.keys()) mainNodes.push(key);
 		
 		// find modules nodes
+		var exports = [];
 		for (module in modules)
 		{
 			var nodes = Alg.preorder(g, module);

--- a/tool/src/Parser.hx
+++ b/tool/src/Parser.hx
@@ -16,6 +16,7 @@ class Parser
 	public var graph:Graph;
 	public var rootBody:Array<AstNode>;
 	public var isHot:Map<String, Bool>;
+	public var isEnum:Map<String, Bool>;
 	
 	var step:ParseStep;
 	var candidates:Map<String, AstNode>;
@@ -83,6 +84,7 @@ class Parser
 		init = new Map();
 		requires = new Map();
 		isHot = new Map();
+		isEnum = new Map();
 		step = ParseStep.Start;
 		
 		var body = getBodyNodes(program);
@@ -253,7 +255,10 @@ class Parser
 							candidates.set(name, def);
 						case 'ObjectExpression': // enum
 							//trace('(enum?)');
-							if (isEnum(init)) register(name, def);
+							if (isEnumDecl(init)) {
+								isEnum.set(name, true);
+								register(name, def);
+							}
 							else candidates.set(name, def);
 						case 'CallExpression' if (isRequire(init.callee)): // require
 							//trace('(require)');
@@ -314,7 +319,7 @@ class Parser
 		defs.push(def);
 	}
 	
-	function isEnum(node:AstNode) 
+	function isEnumDecl(node:AstNode) 
 	{
 		var props = node.properties;
 		return node.type == 'ObjectExpression'


### PR DESCRIPTION
Hot reloading enums causes issues because enum values comparison based on equality will fail after reloading.
For safety, move all enums in the main bundle.