### PR TITLE
If the type is missing, do not blow up on the haxe check.

### DIFF
--- a/runtime/index.js
+++ b/runtime/index.js
@@ -31,7 +31,7 @@ function refresh(rootElement)
 var _createElement = React.createElement;
 
 React.createElement = function(type) {
-	if (type.__hx_proxy__) {
+	if (type && type.__hx_proxy__) {
 		var proxy = proxies[type.__hx_proxy__];
 		if (!proxy) proxy = proxies[type.__hx_proxy__] = createProxy(type);
 		var args = Array.prototype.slice.call(arguments, 1);


### PR DESCRIPTION
If the type is missing, do not blow up on the haxe check, blow up later, then the console error message will be more informative.

This was caused by attempting to import a react component library. These were wrong:
```
@:jsRequire('react-digraph')
extern class GraphView extends react.ReactComponent  { }

@:jsRequire('react-digraph', 'GraphView')
extern class GraphView extends react.ReactComponent  { }
```

This was correct:

```
@:jsRequire('react-digraph', 'default')
extern class GraphView extends react.ReactComponent  { }
```
