### PR TITLE
Performance improvement

### DIFF
--- a/bin/cmd.js
+++ b/bin/cmd.js
@@ -25,18 +25,16 @@ const modules = args.slice(4);
 
 const split = require('../tool/bin/split');
 const result = split.run(input, output, modules, debugMode, webpackMode || nodejsMode, debugSourceMap, dump);
-
 for (file of result) {
 	if (!file || !file.source) continue;
 	if (file.map) {
 		writeIfChanged(file.map.path, file.map.content);
 	}
-	if (file.source) {
-		const content = file.map
-			? `${file.source.content}\n//# sourceMappingURL=${path.basename(file.map.path)}`
-			: file.source.content;
-		writeIfChanged(file.source.path, content);
-	}
+	const content = file.map
+		? `${file.source.content}\n//# sourceMappingURL=${path.basename(file.map.path)}`
+		: file.source.content;
+	writeIfChanged(file.source.path, content);
+
 	if (file.debugMap) {
 		writeIfChanged(file.source.path + '.map.html', file.debugMap);
 	}

--- a/build.hxml
+++ b/build.hxml
@@ -5,4 +5,6 @@ Main
 
 --macro includeFile('tool/src/generateHtml.js')
 
+#-D verbose_debug
+
 -cmd haxe test.hxml

--- a/src/Bundle.hx
+++ b/src/Bundle.hx
@@ -31,6 +31,7 @@ class Bundle
 					Require.module($v{module})
 						.then(function(id:String) {
 							$bridge;
+							var _ = untyped $i{module}; // forced reference
 							return id;
 						});
 				}

--- a/src/Split.hx
+++ b/src/Split.hx
@@ -42,7 +42,7 @@ class Split
 
 		// resolve haxe-split
 		#if haxe_split
-		var params = Compiler.getDefine('haxe_split').split(' ');
+		var params = Std.string(Compiler.getDefine('haxe_split')).split(' ');
 		var cmd = params.shift();
 		if (params.length > 0) args = params.concat(args);
 
@@ -62,6 +62,8 @@ class Split
 			#if nodejs '-nodejs', #end
 		];
 		args = args.concat(bundles).concat(options);
+
+		//Sys.println(cmd + ' ' + args.join(' '));
 		Sys.command(cmd, args);
 	}
 }

--- a/test.hxml
+++ b/test.hxml
@@ -1,5 +1,3 @@
-# [1] build test web project
-
 # local -lib modular
 -cp src
 extraParams.hxml
@@ -8,6 +6,10 @@ extraParams.hxml
 -D haxe_split=node bin/cmd.js
 
 -cp tool/test/src
+
+--each
+# [1] build test web project
+
 -main Main
 -js tool/test/bin/client/index.js
 
@@ -23,15 +25,8 @@ extraParams.hxml
 # [2] build test node project
 
 -lib hxnodejs
+#-D hxnodejs_no_version_warning
 
-# local -lib modular
--cp src
-extraParams.hxml
-
-# local haxe-split
--D haxe_split=node bin/cmd.js
-
--cp tool/test/src
 -main ServerMain
 -js tool/test/bin/server/index.js
 

--- a/tool/src/Extractor.hx
+++ b/tool/src/Extractor.hx
@@ -7,6 +7,7 @@ typedef Bundle = {
 	isLib:Bool,
 	name:String,
 	nodes:Array<String>,
+	indexes:Array<Int>,
 	exports:Array<String>,
 	shared:Array<String>,
 	imports:Array<String>
@@ -32,6 +33,7 @@ class Extractor
 				isLib: false,
 				name: 'Main',
 				nodes: [],
+				indexes: [],
 				exports: [],
 				shared: [],
 				imports: []
@@ -41,6 +43,12 @@ class Extractor
 
 		trace('Bundling...');
 		var g = parser.graph;
+
+		// link "orphan" classes to main module
+		var sources = g.sources();
+		for (source in sources)
+			if (source != mainModule)
+				g.setEdge(mainModule, source);
 
 		// deduplicate modules
 		var modules = [];
@@ -84,6 +92,7 @@ class Extractor
 			isLib: false,
 			name: 'Main',
 			nodes: mainNodes,
+			indexes: [],
 			exports: mainExports,
 			shared: [],
 			imports: mainImports
@@ -101,6 +110,7 @@ class Extractor
 				isLib: true,
 				name: parts[0],
 				nodes: g.nodes().filter(function (n) return test.match(n)),
+				indexes: [],
 				exports: [],
 				shared: [],
 				imports: []
@@ -111,6 +121,7 @@ class Extractor
 			isLib: false,
 			name: name,
 			nodes: Alg.preorder(g, name),
+			indexes: [],
 			exports: [name],
 			shared: [],
 			imports: []

--- a/tool/src/Main.hx
+++ b/tool/src/Main.hx
@@ -11,7 +11,7 @@ class Main
 	{
 		// parse input
 		var src = Fs.readFileSync(input).toString();
-		var parser = new Parser(src);
+		var parser = new Parser(src, debugMode);
 		var sourceMap = debugMode ? new SourceMap(input, src) : null;
 		if (dump) dumpGraph(output, parser);
 

--- a/tool/src/Parser.hx
+++ b/tool/src/Parser.hx
@@ -21,10 +21,10 @@ class Parser
 
 	var types:DynamicAccess<Array<AstNode>>;
 
-	public function new(src:String)
+	public function new(src:String, withLocation:Bool)
 	{
 		var t0 = Date.now().getTime();
-		processInput(src);
+		processInput(src, withLocation);
 		var t1 = Date.now().getTime();
 		trace('Parsed in: ${t1 - t0}ms');
 
@@ -33,9 +33,10 @@ class Parser
 		trace('Graph processed in: ${t2 - t1}ms');
 	}
 
-	function processInput(src:String)
+	function processInput(src:String, withLocation:Bool)
 	{
-		var program = Acorn.parse(src, { ecmaVersion:5, locations:true });
+		var options:AcornOptions = withLocation ? { ecmaVersion:5, locations:true } : { ecmaVersion:5 };
+		var program = Acorn.parse(src, options);
 		walkProgram(program);
 	}
 
@@ -78,7 +79,6 @@ class Parser
 	function walkProgram(program:AstNode)
 	{
 		types = {};
-		isHot = {};
 		isEnum = {};
 		isRequire = {};
 
@@ -209,6 +209,7 @@ class Parser
 	// Identify types with both `displayName` and `__fileName__` as set-up for hotreload
 	function trySetHot(name:String)
 	{
+		if (isHot == null) isHot = {};
 		// first set isHot to false, then true when both properties are seen
 		if (isHot.exists(name)) isHot.set(name, true);
 		else isHot.set(name, false);

--- a/tool/test/src/Main.hx
+++ b/tool/test/src/Main.hx
@@ -3,7 +3,7 @@ package;
 import foo.Bar;
 import js.Browser;
 
-class Main
+class Main extends Shared
 {
 	static function main()
 	{
@@ -12,9 +12,17 @@ class Main
 
 	public function new()
 	{
+		super();
 		trace('new Main');
+		share('Main');
+		trace(Type.resolveClass('Keeped') != null ? '(has Keeped)' : '(uh oh, Keeped is missing)');
+
 		var body = Browser.document.body;
 		body.onclick = click;
+
+		Bundle.load(Unused).then(function(_) {
+			trace('Not doing anything concrete with it');
+		});
 	}
 
 	function click(_)
@@ -27,5 +35,14 @@ class Main
 				trace('still ok');
 			});
 		});
+	}
+}
+
+@:keep
+class Keeped
+{
+	public function new()
+	{
+		trace('This class needs to be kept');
 	}
 }

--- a/tool/test/src/ServerMain.hx
+++ b/tool/test/src/ServerMain.hx
@@ -4,8 +4,25 @@ import foo.Bar;
 
 class ServerMain
 {
+	static var runner:ServerRunner;
+
     static public function main()
     {
+		runner = new ServerRunner();
+		runner.run();
+	}
+}
+
+class ServerRunner extends Shared
+{
+	public function new()
+	{
+		super();
+		share('ServerRunner');
+	}
+
+	public function run()
+	{
         trace('1. Synchronous require');
         Bundle.load(Bar).then(function(_) {
             var b = new Bar();
@@ -15,7 +32,17 @@ class ServerMain
 			});
         });
         trace('2. Done');
+		trace(Type.resolveClass('Keeped') != null ? '(has Keeped)' : '(uh oh, Keeped is missing)');
 
         var route = RouteBundle.load(Bar);
     }
+}
+
+@:keep
+class Keeped
+{
+	public function new()
+	{
+		trace('This class needs to be kept');
+	}
 }

--- a/tool/test/src/Shared.hx
+++ b/tool/test/src/Shared.hx
@@ -1,0 +1,13 @@
+package;
+
+class Shared
+{
+	public function new()
+	{
+	}
+
+	public function share(from:String)
+	{
+		trace('(Shared used from $from)');
+	}
+}

--- a/tool/test/src/Unused.hx
+++ b/tool/test/src/Unused.hx
@@ -1,0 +1,10 @@
+package;
+
+@:keep
+class Unused
+{
+	public function new()
+	{
+		trace('I\'m not used');
+	}
+}

--- a/tool/test/src/foo/Gee.hx
+++ b/tool/test/src/foo/Gee.hx
@@ -1,10 +1,12 @@
 package foo;
 
-class Gee
+class Gee extends Shared
 {
 	public function new()
 	{
+		super();
 		trace('4. new Gee');
+		share('Gee');
 		Bundle.load(Moo).then(function(_) {
 			var m = new Moo();
 		});


### PR DESCRIPTION
- don't create Acorn locations if not required (eg. only for sourcemaps)
- don't clone and loop all the body nodes for each bundle (only main one)
- keep non-directly referenced code (previously was dropped); expecting that it is used through reflection so we're keeping them in the main bundle
  