### PR TITLE
Fixes: Classes with underscores not loaded #45

### DIFF
--- a/src/Bundle.hx
+++ b/src/Bundle.hx
@@ -13,7 +13,7 @@ class Bundle
 		switch (Context.typeof(classRef))
 		{
 			case Type.TType(_.get() => t, _):
-				var module = t.module.split('.').join('_');
+				var module = t.module.split('_').join('_$').split('.').join('_');
 				Split.register(module);
 				var bridge = macro untyped $i{module} = $p{["$s", module]};
 				#if nodejs

--- a/src/RouteBundle.hx
+++ b/src/RouteBundle.hx
@@ -12,7 +12,7 @@ class RouteBundle
 		switch (Context.typeof(reactClassRef))
 		{
 			case Type.TType(_.get() => t, _):
-				var module = t.module.split('.').join('_');
+				var module = t.module.split('_').join('_$').split('.').join('_');
 				Split.register(module);
 				var bridge = macro untyped $i{module} = $p{["$s", module]};
 				#if nodejs

--- a/tool/bin/split.js
+++ b/tool/bin/split.js
@@ -1321,5 +1321,3 @@ Bundler.FRAGMENTS = { MAIN : { EXPORTS : "var $hx_exports = exports, $global = g
 Bundler.generateHtml = global.generateHtml;
 SourceMap.SRC_REF = "//# sourceMappingURL=";
 })(typeof exports != "undefined" ? exports : typeof window != "undefined" ? window : typeof self != "undefined" ? self : this);
-
-//# sourceMappingURL=split.js.map

--- a/tool/test/src/foo/Bar.hx
+++ b/tool/test/src/foo/Bar.hx
@@ -11,8 +11,8 @@ class Bar
 		var c = [1, 2, 3];
 		c.push(d);
 
-		Bundle.load(Sub).then(function(_) {
-			var s = new Sub();
+		Bundle.load(Sub__M).then(function(_) {
+			var s = new Sub__M();
 		});
 
 		var g = new Gee();

--- a/tool/test/src/foo/Sub__M.hx
+++ b/tool/test/src/foo/Sub__M.hx
@@ -1,9 +1,9 @@
 package foo;
 
-class Sub
+class Sub__M
 {
 	public function new()
 	{
-		trace('6. Sub');
+		trace('6. Sub__M');
 	}
 }


### PR DESCRIPTION
Haxe classes with underscore are transformed:
```
The_Class => The_$Class
The__Class => The_$_$Class
```