### PR TITLE
Graph processing hook

### DIFF
--- a/doc/advanced.md
+++ b/doc/advanced.md
@@ -43,10 +43,10 @@ load(ABFactory).then(function(_) {
 
 Using reflection (e.g. `Type.resolveClass`) is an interesting edge case:
 
-- Using reflection, no visible relationship is available to Modular to 
+- Using reflection, no visible relationship is available to Modular to
   attribute the class to a specific part of the graph.
-  
-- By default, non-attributed classes (and their dependencies) will land in the 
+
+- By default, non-attributed classes (and their dependencies) will land in the
   main bundle. It often can be undesirable.
 
 A simple solution is to somehow add this explicit relationship through code:
@@ -56,6 +56,7 @@ class A {...}
 
 class B {
 	// Not very elegant, but explicit
+	@:keep
 	static private var reflected = [A];
 
 	function new() {
@@ -68,18 +69,18 @@ class B {
 
 ## Controlled bundling
 
-The natural bundling strategy may have limitations that you don't want to 
+The natural bundling strategy may have limitations that you don't want to
 use workaround for, or maybe your project is very large and highly dynamic.
 
 Modular (both [standalone](start.md) or [Webpack Haxe Loader](https://github.com/jasononeil/webpack-haxe-loader))
 allow advanced users to finely control the bundling process.
 
-The approach is to allow you to provide a "hook" script which will have 
+The approach is to allow you to provide a "hook" script which will have
 all freedom to modify the dependency graph.
 
 ### Set up
 
-Hooks are declared in your project's `package.json`, as a single file 
+Hooks are declared in your project's `package.json`, as a single file
 or a list of files.
 
 ```javascript
@@ -107,14 +108,14 @@ or a list of files.
 
 A hook is a simple JavaScript file which should export a function.
 
-The hook runs on **node.js**, so you have access to the entire library 
+The hook runs on **node.js**, so you have access to the entire library
 of node modules.
 
 #### Arguments
 
 This function will receive:
 
-- the graph of your project 
+- the graph of your project
   (see [Graphlib documentation](https://github.com/dagrejs/graphlib/wiki)),
 - the name of the entry point class.
 
@@ -139,7 +140,7 @@ This function can return:
  */
 module.exports = function(graph, root) {
 	console.log(
-		'Hook called with', graph.nodes().length, 
+		'Hook called with', graph.nodes().length,
 		'nodes and "' + root + '" entry point');
 
 	// Modify the graph here.
@@ -167,8 +168,8 @@ If you have any doubt, look inside the generated source code!
 
 ### Solving Reflection limitation
 
-Now we can solve the missing attribution due to reflection and 
-create the link between the dynamicall created class and 
+Now we can solve the missing attribution due to reflection and
+create the link between the dynamicall created class and
 some class of the module it should belong:
 
 ```javascript
@@ -190,11 +191,11 @@ module.exports = function(graph, root) {
 
 	// create a node for the bundle
 	graph.setNode('DynBundle');
-	
+
 	// assign nodes to this bundle
 	graph.setEdge('foo_ReflectedClass1', 'DynBundle');
 	graph.setEdge('foo_ReflectedClass2', 'DynBundle');
-	
+
 	// register the bundle
 	return ['DynBundle'];
 }

--- a/doc/advanced.md
+++ b/doc/advanced.md
@@ -1,0 +1,212 @@
+# Advanced control of the splitting logic
+
+## "Natural" bundling strategy
+
+For most project it should be sufficient to let Modular work automatically
+using the natural relationship of your code:
+
+- Every explicit dependency will appear in the code and allow Modular to
+  build a **graph** of the types of your project.
+
+- When splitting a class, it is equivalent to breaking the graph into separate
+  graphs; one for your main entry point, and one for each of your modules.
+
+
+### Splitting several classes in one bundle
+
+Normally splitting the class is done on a single class, and the bundle
+will include all its dependencies.
+
+The recommended approach to bundle several classes is creating a factory:
+
+```haxe
+class A {...}
+
+class B {...}
+
+class ABFactory {
+	static function createA():A {
+		return new A();
+	}
+	static function createB():B {
+		return new B();
+	}
+}
+
+load(ABFactory).then(function(_) {
+	var a:A = ABFactory.createA();
+})
+```
+
+
+### Using Reflection
+
+Using reflection (e.g. `Type.resolveClass`) is an interesting edge case:
+
+- Using reflection, no visible relationship is available to Modular to 
+  attribute the class to a specific part of the graph.
+  
+- By default, non-attributed classes (and their dependencies) will land in the 
+  main bundle. It often can be undesirable.
+
+A simple solution is to somehow add this explicit relationship through code:
+
+```haxe
+class A {...}
+
+class B {
+	// Not very elegant, but explicit
+	static private var reflected = [A];
+
+	function new() {
+		// the string 'A' is not enough to establish the relationship
+		var a = Type.createInstance( Type.resolveClass('A') );
+	}
+}
+
+```
+
+## Controlled bundling
+
+The natural bundling strategy may have limitations that you don't want to 
+use workaround for, or maybe your project is very large and highly dynamic.
+
+Modular (both [standalone](start.md) or [Webpack Haxe Loader](https://github.com/jasononeil/webpack-haxe-loader))
+allow advanced users to finely control the bundling process.
+
+The approach is to allow you to provide a "hook" script which will have 
+all freedom to modify the dependency graph.
+
+### Set up
+
+Hooks are declared in your project's `package.json`, as a single file 
+or a list of files.
+
+```javascript
+// package.json
+{
+  "name": "My Project",
+  ...
+  "config": {
+    "haxe-split-hook": "script/my_hook.js"
+  }
+}
+```
+```javascript
+// package.json
+{
+  "name": "My Project",
+  ...
+  "config": {
+    "haxe-split-hook": ["script/my_hook.js", "script/my_other_hook.js"]
+  }
+}
+```
+
+### Hook format
+
+A hook is a simple JavaScript file which should export a function.
+
+The hook runs on **node.js**, so you have access to the entire library 
+of node modules.
+
+#### Arguments
+
+This function will receive:
+
+- the graph of your project 
+  (see [Graphlib documentation](https://github.com/dagrejs/graphlib/wiki)),
+- the name of the entry point class.
+
+#### Response
+
+This function can return:
+
+- nothing, or
+- an additional list of nodes which should be split.
+
+
+```javascript
+// my_hook.js
+
+// Setup code goes here.
+
+/**
+ * This is your hook
+ * @param  {graphlib.Graph}  graph  Identifiers graph
+ * @param  {String}          root   Root node
+ * @return {String[]} Additional modules to split (identifiers)
+ */
+module.exports = function(graph, root) {
+	console.log(
+		'Hook called with', graph.nodes().length, 
+		'nodes and "' + root + '" entry point');
+
+	// Modify the graph here.
+}
+```
+
+### Relationship between nodes and Haxe types
+
+Each Haxe type will appear as a node; in the case of a module,
+every type in the module will be a distinct node.
+
+Type names are transformed in the compilation process:
+
+- underscores become `_$`
+- dots become underscores `_`
+
+```
+com.foo.Bar -> com_foo_Bar
+Pascal_case -> Pascal_$case
+Even__worse -> Even_$_$worse
+
+```
+
+If you have any doubt, look inside the generated source code!
+
+### Solving Reflection limitation
+
+Now we can solve the missing attribution due to reflection and 
+create the link between the dynamicall created class and 
+some class of the module it should belong:
+
+```javascript
+module.exports = function(graph, root) {
+
+	// link the reflected class to its parent
+	graph.setEdge('module1_ReflectedClass', 'module1_App');
+}
+```
+
+### Grouping multiple classes in a bundle
+
+If you're going to use reflection anyway, you can as well go
+and group these classes together in a single bundle without
+having to create a factory class:
+
+```javascript
+module.exports = function(graph, root) {
+
+	// create a node for the bundle
+	graph.setNode('DynBundle');
+	
+	// assign nodes to this bundle
+	graph.setEdge('foo_ReflectedClass1', 'DynBundle');
+	graph.setEdge('foo_ReflectedClass2', 'DynBundle');
+	
+	// register the bundle
+	return ['DynBundle'];
+}
+```
+
+Modular will split out the 2 classes and emit `DynBundle.js`.
+
+To load this bundle, use Modular's `Require.module` API:
+
+```haxe
+Require.module('DynBundle').then(function(_) {
+	var rc1 = Type.createInstance( Type.resolveClass('foo.ReflectedClass1') );
+	// notice that this is the normal qualified Haxe type name:
+})
+```

--- a/package.json
+++ b/package.json
@@ -23,5 +23,8 @@
     "react-deep-force-update": "^2.0.1",
     "react-proxy": "^2.0.8",
     "source-map": "^0.6.1"
+  },
+  "config": {
+    "haxe-split-hook": "tool/test/src/test_hook.js"
   }
 }

--- a/readme.md
+++ b/readme.md
@@ -14,8 +14,8 @@ you probably want to:
 Haxe has an excellent, compact and optimised JS output, but it's always a single file; 
 even with good minification / gzip compression it can be a large payload.
 
-**Modular can split Haxe-JS output into load-on-demand features, without size/speed overhead,
-and without losing sourcemaps.**
+*Modular can split gigantic Haxe-JS outputs into load-on-demand features, 
+without size/speed overhead, and without losing sourcemaps.*
 
 ## How?
 
@@ -41,30 +41,33 @@ entire packages; it is "usage" based and can slice the biggest libraries to keep
 
 There are 2 ways to use Haxe Modular, depending on your project/toolchain/goals:
 
-- [standalone Modular](doc/start.md); zero dependencies, drop-in any Haxe-JS project,
-- [Webpack Haxe Loader](https://github.com/jasononeil/webpack-haxe-loader); leverage 
-the famous JS toolchain.
+1. [standalone Modular](doc/start.md); zero dependencies, for any Haxe-JS project,
+2. [Webpack Haxe Loader](https://github.com/jasononeil/webpack-haxe-loader); 
+   leverage the famous JS toolchain.
 
 In both cases, it is advisable to read about the technical details: 
-[how does Haxe compile to JavaScript, and how does on-demand loading work?](doc/how.md).
+
+- [How does Haxe compile to JavaScript, and how does on-demand loading work?](doc/how.md)
+- [How to add advanced control of the splitting logic?](doc/advanced.md)
 
 ### What is the difference?
 
 Both solutions:
 
-- use Modular splitting under the hood.
+- use Modular splitting under the hood,
 - split automatically using a single `hxml` build configuration,
 - support NPM dependencies,
 - allow hot-reloading of code.
 
 ### What should I use?
 
-**[Standalone Modular](doc/start.md)** is quite easy to drop in an regular Haxe JS build 
-process - it is very lightweight and unobstrusive, and you don't need to learn Webpack.
+1. [Standalone Modular](doc/start.md) is an easy, drop-in, addition to a regular 
+   Haxe JS build process - it is very lightweight and unobstrusive, and you don't need 
+   to learn Webpack.
 
-Using NPM modules however requires a bit a ceremony: all the NPM dependencies have to be 
-gathered (manually) in a `libs.js` which is loaded upfront.
+   Using NPM modules however requires a bit of ceremony: all the NPM dependencies have to 
+   be gathered (manually) in a `libs.js` which is loaded upfront.
 
-**[Webpack Haxe Loader](https://github.com/jasononeil/webpack-haxe-loader)** is a more 
-powerful setup but you'll have to learn Webpack. Webpack is a complex and large system 
-offering vast possibilities from the JS ecosystem.
+2. [Webpack Haxe Loader](https://github.com/jasononeil/webpack-haxe-loader) is a more 
+   powerful setup but you'll have to learn Webpack. Webpack is a complex and large system 
+   offering vast possibilities from the JS ecosystem.

--- a/readme.md
+++ b/readme.md
@@ -4,17 +4,17 @@ Code splitting and hot-reload for Haxe JavaScript applications.
 
 ## Why?
 
-If you use **Haxe for JavaScript**, directly or indirectly (OpenFl, Kha...), then 
+If you use **Haxe for JavaScript**, directly or indirectly (OpenFl, Kha...), then
 you probably want to:
 
 - make your web app load instantly,
 - make your HTML5 game load quicker,
 - load sections / features / mini-games on-demand.
 
-Haxe has an excellent, compact and optimised JS output, but it's always a single file; 
+Haxe has an excellent, compact and optimised JS output, but it's always a single file;
 even with good minification / gzip compression it can be a large payload.
 
-*Modular can split gigantic Haxe-JS outputs into load-on-demand features, 
+*Modular can split gigantic Haxe-JS outputs into load-on-demand features,
 without size/speed overhead, and without losing sourcemaps.*
 
 ## How?
@@ -35,17 +35,18 @@ file will be emitted (bundling this class and all its dependencies),
 loaded (once) automatically.
 
 Note: Haxe Modular is NOT a solution for extracting libraries, single files or
-entire packages; it is "usage" based and can slice the biggest libraries to keep only .
+entire packages; it is "usage" based and can slice the biggest libraries to keep only
+what you really use, where you really use it.
 
 ## Where to start?
 
 There are 2 ways to use Haxe Modular, depending on your project/toolchain/goals:
 
 1. [standalone Modular](doc/start.md); zero dependencies, for any Haxe-JS project,
-2. [Webpack Haxe Loader](https://github.com/jasononeil/webpack-haxe-loader); 
+2. [Webpack Haxe Loader](https://github.com/jasononeil/webpack-haxe-loader);
    leverage the famous JS toolchain.
 
-In both cases, it is advisable to read about the technical details: 
+In both cases, it is advisable to read about the technical details:
 
 - [How does Haxe compile to JavaScript, and how does on-demand loading work?](doc/how.md)
 - [How to add advanced control of the splitting logic?](doc/advanced.md)
@@ -61,13 +62,13 @@ Both solutions:
 
 ### What should I use?
 
-1. [Standalone Modular](doc/start.md) is an easy, drop-in, addition to a regular 
-   Haxe JS build process - it is very lightweight and unobstrusive, and you don't need 
+1. [Standalone Modular](doc/start.md) is an easy, drop-in, addition to a regular
+   Haxe JS build process - it is very lightweight and unobstrusive, and you don't need
    to learn Webpack.
 
-   Using NPM modules however requires a bit of ceremony: all the NPM dependencies have to 
+   Using NPM modules however requires a bit of ceremony: all the NPM dependencies have to
    be gathered (manually) in a `libs.js` which is loaded upfront.
 
-2. [Webpack Haxe Loader](https://github.com/jasononeil/webpack-haxe-loader) is a more 
-   powerful setup but you'll have to learn Webpack. Webpack is a complex and large system 
+2. [Webpack Haxe Loader](https://github.com/jasononeil/webpack-haxe-loader) is a more
+   powerful setup but you'll have to learn Webpack. Webpack is a complex and large system
    offering vast possibilities from the JS ecosystem.

--- a/tool/bin/split.js
+++ b/tool/bin/split.js
@@ -381,6 +381,7 @@ Bundler.prototype = {
 		return results;
 	}
 	,buildIndex: function(src) {
+		var ids = this.idMap = { };
 		var rev = this.revMap;
 		var body = this.parser.rootBody;
 		var bodyLength = body.length;
@@ -399,6 +400,7 @@ Bundler.prototype = {
 					this.bundles[j].indexes.push(i);
 				}
 			} else if(node.__tag__ != "__reserved__") {
+				ids[node.__tag__] = true;
 				var list = rev[node.__tag__];
 				if(list == null) {
 					list = [0];
@@ -564,7 +566,9 @@ Bundler.prototype = {
 			while(_g5 < exports.length) {
 				var node3 = exports[_g5];
 				++_g5;
-				buffer += "$" + "s." + node3 + " = " + node3 + "; ";
+				if(Object.prototype.hasOwnProperty.call(this.idMap,node3)) {
+					buffer += "$" + "s." + node3 + " = " + node3 + "; ";
+				}
 			}
 			buffer += "\n";
 		}
@@ -888,17 +892,16 @@ Main.run = $hx_exports["run"] = function(input,output,modules,debugMode,commonjs
 	var src = js_node_Fs.readFileSync(input).toString();
 	var parser = new Parser(src,debugMode);
 	var sourceMap = debugMode ? new SourceMap(input,src) : null;
-	modules = Main.applyAstHooks(modules,astHooks,parser.graph);
+	modules = Main.applyAstHooks(parser.mainModule,modules,astHooks,parser.graph);
 	if(dump) {
-		Main.dumpGraph(output,parser);
+		Main.dumpGraph(output,parser.graph);
 	}
 	var extractor = new Extractor(parser);
 	extractor.process(parser.mainModule,modules,debugMode);
 	var bundler = new Bundler(parser,sourceMap,extractor);
-	var dir = js_node_Path.dirname(output);
 	return bundler.generate(src,output,commonjs,debugSourceMap);
 };
-Main.applyAstHooks = function(modules,astHooks,graph) {
+Main.applyAstHooks = function(mainModule,modules,astHooks,graph) {
 	if(astHooks == null || astHooks.length == 0) {
 		return modules;
 	}
@@ -909,15 +912,14 @@ Main.applyAstHooks = function(modules,astHooks,graph) {
 		if(hook == null) {
 			continue;
 		}
-		var addModules = hook(graph);
+		var addModules = hook(graph,mainModule);
 		if(addModules != null) {
 			modules = modules.concat(addModules);
 		}
 	}
 	return modules;
 };
-Main.dumpGraph = function(output,parser) {
-	var g = parser.graph;
+Main.dumpGraph = function(output,g) {
 	console.log("Dump graph: " + output + ".graph");
 	var out = "";
 	var _g = 0;

--- a/tool/src/Bundler.hx
+++ b/tool/src/Bundler.hx
@@ -55,6 +55,7 @@ class Bundler
 	var debugSourceMap:Bool;
 	var nodejsMode:Bool;
 	var revMap:DynamicAccess<Array<Int>>;
+	var idMap:DynamicAccess<Bool>;
 	var bundles:Array<Bundle>;
 
 	public function new(parser:Parser, sourceMap:SourceMap, extractor:Extractor)
@@ -104,6 +105,7 @@ class Bundler
 		#if verbose_debug
 		trace('Build index...');
 		#end
+		var ids = idMap = {};
 		var rev = revMap;
 		var body = parser.rootBody;
 		var bodyLength = body.length;
@@ -125,6 +127,7 @@ class Bundler
 			}
 			// Non-reserved nodes go in matching bundle
 			else if (node.__tag__ != '__reserved__') {
+				ids.set(node.__tag__, true);
 				var list = rev.get(node.__tag__);
 				if (list == null) list = [0];
 
@@ -297,7 +300,8 @@ class Bundler
 		if (exports.length > 0)
 		{
 			for (node in exports)
-				buffer += '$$s.$node = $node; ';
+				if (idMap.exists(node))
+					buffer += '$$s.$node = $node; ';
 			buffer += '\n';
 		}
 

--- a/tool/test/src/test_hook.js
+++ b/tool/test/src/test_hook.js
@@ -1,4 +1,4 @@
-console.log('AST hook loaded');
+console.log('[Hook] loaded');
 
 /**
  * Graph post-processor hook
@@ -7,7 +7,7 @@ console.log('AST hook loaded');
  * @return {String[]} Additional modules to split (identifiers)
  */
 module.exports = function(graph, root) {
-    console.log('[AST hook called] with', graph.nodes().length, 'nodes and "' + root + '" entry point');
+    console.log('[Hook] called with', graph.nodes().length, 'nodes and "' + root + '" entry point');
 
     // you can define virtual nodes
     graph.setNode('fakeNode');

--- a/tool/test/src/test_hook.js
+++ b/tool/test/src/test_hook.js
@@ -1,0 +1,21 @@
+console.log('AST hook loaded');
+
+/**
+ * Graph post-processor hook
+ * @param {graphlib.Graph} graph Identifiers graph
+ * @param {String} root Root node (entry point)
+ * @return {String[]} Additional modules to split (identifiers)
+ */
+module.exports = function(graph, root) {
+    console.log('[AST hook called] with', graph.nodes().length, 'nodes and "' + root + '" entry point');
+
+    // you can define virtual nodes
+    graph.setNode('fakeNode');
+    // you can link/unlink nodes
+    graph.setEdge(root, 'fakeNode');
+    graph.setEdge('foo_Bar', 'fakeNode');
+
+    // you can return additional modules to split
+    // return ['Keeped'];
+    return null;
+}


### PR DESCRIPTION
Expose a mechanism to provide to the `haxe-split` command a JS hook, allowing users to customise the identifiers graph to:

- control classes relations; can be used to break or create relations between classes, for example to solve the absence of relation between classes when Reflection is used,
- programmatically return an arbitrary number of classes to be split, without using `Bundle.load(Abc)` or `--macro Split.register('Abc')`.

Hook file(s) should be defined in the user's `package.json` under `config.haxe-split-hook`, as a string or array of string (paths to JS files):

```
  "config": {
     "haxe-split-hook": "script/my_hook.js"
  }
```
```
  "config": {
    "haxe-split-hook": ["script/my_hook.js", "script/my_other_hook.js"]
  }
```