### PR TITLE
Fix sharing of `$estr` and `$hxClasses` between main and modules.

### DIFF
--- a/tool/bin/split.js
+++ b/tool/bin/split.js
@@ -566,7 +566,7 @@ Bundler.prototype = {
 			while(_g5 < exports.length) {
 				var node3 = exports[_g5];
 				++_g5;
-				if(Object.prototype.hasOwnProperty.call(this.idMap,node3)) {
+				if(node3.charAt(0) == "$" || Object.prototype.hasOwnProperty.call(this.idMap,node3)) {
 					buffer += "$" + "s." + node3 + " = " + node3 + "; ";
 				}
 			}
@@ -657,13 +657,22 @@ Extractor.prototype = {
 			moduleRefs[module1] = g.predecessors(module1);
 			this.unlink(g,module1);
 		}
+		var _g3 = 0;
+		var _g11 = ["$estr","$hxClasses"];
+		while(_g3 < _g11.length) {
+			var enforce = _g11[_g3];
+			++_g3;
+			if(g.hasNode(enforce) && !g.hasEdge(mainModule,enforce)) {
+				g.setEdge(mainModule,enforce);
+			}
+		}
 		var mainNodes = graphlib_Alg.preorder(g,mainModule);
 		if(debugMode) {
-			var _g3 = 0;
-			var _g11 = Reflect.fields(this.parser.isEnum);
-			while(_g3 < _g11.length) {
-				var key = _g11[_g3];
-				++_g3;
+			var _g4 = 0;
+			var _g12 = Reflect.fields(this.parser.isEnum);
+			while(_g4 < _g12.length) {
+				var key = _g12[_g4];
+				++_g4;
 				mainNodes.push(key);
 			}
 		}
@@ -671,11 +680,11 @@ Extractor.prototype = {
 		var dupes = this.deduplicate(this.bundles,mainNodes,debugMode);
 		mainNodes = this.addOnce(mainNodes,dupes.removed);
 		var mainExports = dupes.shared;
-		var _g4 = 0;
-		var _g12 = this.bundles;
-		while(_g4 < _g12.length) {
-			var bundle = _g12[_g4];
-			++_g4;
+		var _g5 = 0;
+		var _g13 = this.bundles;
+		while(_g5 < _g13.length) {
+			var bundle = _g13[_g5];
+			++_g5;
 			if(bundle.isLib) {
 				mainNodes = this.remove(bundle.nodes,mainNodes);
 				mainExports = this.remove(bundle.nodes,mainExports);
@@ -1215,7 +1224,9 @@ Parser.prototype = {
 		} else {
 			this.types[name].push(def);
 		}
-		def.__tag__ = name;
+		if(def.__tag__ == null) {
+			def.__tag__ = name;
+		}
 	}
 	,isReserved: function(name) {
 		return this.reservedTypes[name];

--- a/tool/src/Bundler.hx
+++ b/tool/src/Bundler.hx
@@ -300,7 +300,7 @@ class Bundler
 		if (exports.length > 0)
 		{
 			for (node in exports)
-				if (idMap.exists(node))
+				if (node.charAt(0) == '$' || idMap.exists(node))
 					buffer += '$$s.$node = $node; ';
 			buffer += '\n';
 		}

--- a/tool/src/Extractor.hx
+++ b/tool/src/Extractor.hx
@@ -62,6 +62,12 @@ class Extractor
 			unlink(g, module);
 		}
 
+		// force some links
+		for (enforce in ["$estr", "$hxClasses"]) {
+			if (g.hasNode(enforce) && !g.hasEdge(mainModule, enforce))
+				g.setEdge(mainModule, enforce);
+		}
+
 		// find main nodes
 		var mainNodes = Alg.preorder(g, mainModule);
 

--- a/tool/src/Parser.hx
+++ b/tool/src/Parser.hx
@@ -231,8 +231,9 @@ class Parser
 							tag(name, def);
 						case 'AssignmentExpression':
 							var right = init.right;
-							if (right.type == 'FunctionExpression') // ctor with export
+							if (right.type == 'FunctionExpression') { // ctor with export
 								tag(name, def);
+							}
 							else if (right.type == 'ObjectExpression') { // enum with export
 								if (isEnumDecl(right))
 									isEnum.set(name, true);
@@ -285,7 +286,7 @@ class Parser
 			types.set(name, [def]);
 		}
 		else types.get(name).push(def);
-		def.__tag__ = name;
+		if (def.__tag__ == null) def.__tag__ = name;
 	}
 
 	inline function isReserved(name:String)

--- a/tool/src/graphlib/Graph.hx
+++ b/tool/src/graphlib/Graph.hx
@@ -20,6 +20,7 @@ extern class Graph
 
 	public function setNode(v:String, ?label:String):Void;
 	public function node(v:String):String;
+	public function hasNode(v:String):Bool;
 	public function removeNode(v:String):Void;
 	public function nodes():Array<String>;
 	public function nodeCount():Int;

--- a/tool/test/src/foo/Bar.hx
+++ b/tool/test/src/foo/Bar.hx
@@ -22,7 +22,10 @@ class Bar
 	{
 		trace('5. Bar hello');
 		#if !nodejs
+		// verify HTML compat classes
 		var d = new DataView(null);
+		// verify sharing of $estr
+		var estr = untyped __js__("$estr");
 		#end
 	}
 }


### PR DESCRIPTION
Bug: `$estr` and `$hxClasses` were either missing or duplicated in bundles.
Now they are correctly shared from the main bundle.