### PR TITLE
Fix casting of value types in modules

### DIFF
--- a/tool/bin/split.js
+++ b/tool/bin/split.js
@@ -989,7 +989,7 @@ Main.dumpGraph = function(output,g) {
 	js_node_Fs.writeFileSync(output + ".graph",out);
 };
 var Parser = function(src,withLocation) {
-	this.reservedTypes = { "String" : true, "Math" : true, "Array" : true, "Int" : true, "Float" : true, "Bool" : true, "Class" : true, "Date" : true, "Dynamic" : true, "Enum" : true, __map_reserved : true};
+	this.reservedTypes = { "String" : true, "Math" : true, "Array" : true, "Date" : true, "Number" : true, "Boolean" : true, __map_reserved : true};
 	this.mainModule = "Main";
 	var t0 = new Date().getTime();
 	this.processInput(src,withLocation);
@@ -1188,12 +1188,15 @@ Parser.prototype = {
 					switch(_g1) {
 					case "AssignmentExpression":
 						var right = init.right;
-						if(right.type == "FunctionExpression") {
+						var type = right.type;
+						if(type == "FunctionExpression") {
 							this.tag(name,def);
-						} else if(right.type == "ObjectExpression") {
+						} else if(type == "ObjectExpression") {
 							if(this.isEnumDecl(right)) {
 								this.isEnum[name] = true;
 							}
+							this.tag(name,def);
+						} else if(type == "Identifier") {
 							this.tag(name,def);
 						}
 						break;

--- a/tool/src/Parser.hx
+++ b/tool/src/Parser.hx
@@ -14,8 +14,7 @@ class Parser
 	public var mainModule:String = 'Main';
 
 	var reservedTypes = {
-		'String':true, 'Math':true, 'Array':true, 'Int':true, 'Float':true,
-		'Bool':true, 'Class':true, 'Date':true, 'Dynamic':true, 'Enum': true,
+		'String':true, 'Math':true, 'Array':true, 'Date':true, 'Number':true, 'Boolean':true,
 		__map_reserved:true
 	};
 
@@ -231,12 +230,16 @@ class Parser
 							tag(name, def);
 						case 'AssignmentExpression':
 							var right = init.right;
-							if (right.type == 'FunctionExpression') { // ctor with export
+							var type = right.type;
+							if (type == 'FunctionExpression') { // ctor with export
 								tag(name, def);
 							}
-							else if (right.type == 'ObjectExpression') { // enum with export
+							else if (type == 'ObjectExpression') { // enum with export
 								if (isEnumDecl(right))
 									isEnum.set(name, true);
+								tag(name, def);
+							}
+							else if (type == 'Identifier') { // var Float = Number
 								tag(name, def);
 							}
 						case 'ObjectExpression': // enum
@@ -289,7 +292,7 @@ class Parser
 		if (def.__tag__ == null) def.__tag__ = name;
 	}
 
-	inline function isReserved(name:String)
+	inline function isReserved(name:String):Bool
 	{
 		return untyped reservedTypes[name];
 	}

--- a/tool/test/src/foo/Sub__M.hx
+++ b/tool/test/src/foo/Sub__M.hx
@@ -5,5 +5,6 @@ class Sub__M
 	public function new()
 	{
 		trace('6. Sub__M');
+		var i = cast(0, Int);
 	}
 }


### PR DESCRIPTION
- Incorrect sharing of Haxe value types (Int, Float,..) as opposed to native JS types (String, Date, Math).
- Missing matching of some cases of declarations (`var Float = Number`)

Fixes #54 