### PR TITLE
Fix for isolated modules

### DIFF
--- a/tool/bin/split.js
+++ b/tool/bin/split.js
@@ -1126,12 +1126,15 @@ Parser.prototype = {
 				g.setEdge(id,name);
 				refs += 1;
 			}
+		}, AssignmentExpression : function(node1,state,cont) {
+			cont(node1.right,state);
+			cont(node1.left,state);
 		}};
 		var _g = 0;
 		while(_g < nodes.length) {
 			var decl = nodes[_g];
 			++_g;
-			acorn_Walk.simple(decl,visitors);
+			acorn_Walk.recursive(decl,{ },visitors);
 		}
 		return refs;
 	}

--- a/tool/bin/split.js
+++ b/tool/bin/split.js
@@ -681,6 +681,7 @@ Extractor.prototype = {
 		var libTest = this.expandLibs();
 		var parents = { };
 		this.recurseVisit([mainModule],libTest,parents);
+		this.recurseVisit(this.modules,libTest,parents);
 		this.walkLibs(libTest,parents);
 		this.populateBundles(mainModule,parents);
 		this.main = this.moduleMap[mainModule];
@@ -773,7 +774,7 @@ Extractor.prototype = {
 		while(_g < modules.length) {
 			var $module = modules[_g];
 			++_g;
-			if($module.indexOf("=") > 0 || Object.prototype.hasOwnProperty.call(this.moduleMap,$module)) {
+			if($module.indexOf("=") > 0 || Object.prototype.hasOwnProperty.call(this.moduleMap,$module) || !this.g.hasNode($module)) {
 				continue;
 			}
 			var mod = this.createBundle($module);

--- a/tool/src/Extractor.hx
+++ b/tool/src/Extractor.hx
@@ -76,6 +76,7 @@ class Extractor
 		// process graph
 		var parents = {};
 		recurseVisit([mainModule], libTest, parents);
+		recurseVisit(modules, libTest, parents); // modules can be isolated from entry point
 		walkLibs(libTest, parents);
 		populateBundles(mainModule, parents);
 
@@ -161,7 +162,7 @@ class Extractor
 	{
 		var children = [];
 		for (module in modules) {
-			if (module.indexOf('=') > 0 || moduleMap.exists(module)) continue;
+			if (module.indexOf('=') > 0 || moduleMap.exists(module) || !g.hasNode(module)) continue;
 			var mod = createBundle(module);
 			parents.set(module, module);
 			walkGraph(mod, [module], libTest, parents, children);

--- a/tool/src/Parser.hx
+++ b/tool/src/Parser.hx
@@ -69,9 +69,14 @@ class Parser
 					g.setEdge(id, name);
 					refs++;
 				}
+			},
+			AssignmentExpression: function(node, state, cont) {
+				// force exploring both right and left of expression
+				cont(node.right, state);
+				cont(node.left, state);
 			}
 		};
-		for (decl in nodes) Walk.simple(decl, visitors);
+		for (decl in nodes) Walk.recursive(decl, {}, visitors);
 		return refs;
 	}
 

--- a/tool/test/expect/node-debug-test9.json
+++ b/tool/test/expect/node-debug-test9.json
@@ -2,9 +2,9 @@
   {
     "isMain": true,
     "isLib": false,
-    "name": "Test7",
+    "name": "Test9",
     "nodes": [
-      "Test7",
+      "Test9",
       "$hxClasses",
       "Type"
     ],

--- a/tool/test/expect/node-release-test7.json
+++ b/tool/test/expect/node-release-test7.json
@@ -22,13 +22,18 @@
     "isLib": false,
     "name": "CaseD",
     "nodes": [
-      "CaseD"
+      "CaseD",
+      "CycleD"
     ],
     "indexes": [
       2,
       3,
       4,
-      5
+      5,
+      6,
+      7,
+      8,
+      9
     ],
     "exports": {
       "CaseD": true

--- a/tool/test/expect/node-release-test9.json
+++ b/tool/test/expect/node-release-test9.json
@@ -2,9 +2,9 @@
   {
     "isMain": true,
     "isLib": false,
-    "name": "Test7",
+    "name": "Test9",
     "nodes": [
-      "Test7",
+      "Test9",
       "$hxClasses",
       "Type"
     ],

--- a/tool/test/expect/web-debug-test7.json
+++ b/tool/test/expect/web-debug-test7.json
@@ -28,14 +28,19 @@
     "isLib": false,
     "name": "CaseD",
     "nodes": [
-      "CaseD"
+      "CaseD",
+      "CycleD"
     ],
     "indexes": [
       2,
       3,
       4,
       5,
-      49
+      6,
+      7,
+      8,
+      9,
+      53
     ],
     "exports": {
       "CaseD": true

--- a/tool/test/expect/web-debug-test9.json
+++ b/tool/test/expect/web-debug-test9.json
@@ -2,11 +2,17 @@
   {
     "isMain": true,
     "isLib": false,
-    "name": "Test7",
+    "name": "Test9",
     "nodes": [
-      "Test7",
+      "Test9",
       "$hxClasses",
-      "Type"
+      "Type",
+      "Require",
+      "haxe_Timer",
+      "Std",
+      "js_Boot",
+      "haxe_ds_StringMap",
+      "haxe_IMap"
     ],
     "indexes": [],
     "exports": {
@@ -33,7 +39,8 @@
       6,
       7,
       8,
-      9
+      9,
+      53
     ],
     "exports": {
       "CaseD": true

--- a/tool/test/expect/web-release-test7.json
+++ b/tool/test/expect/web-release-test7.json
@@ -25,14 +25,19 @@
     "isLib": false,
     "name": "CaseD",
     "nodes": [
-      "CaseD"
+      "CaseD",
+      "CycleD"
     ],
     "indexes": [
       2,
       3,
       4,
       5,
-      32
+      6,
+      7,
+      8,
+      9,
+      36
     ],
     "exports": {
       "CaseD": true

--- a/tool/test/expect/web-release-test9.json
+++ b/tool/test/expect/web-release-test9.json
@@ -2,11 +2,14 @@
   {
     "isMain": true,
     "isLib": false,
-    "name": "Test7",
+    "name": "Test9",
     "nodes": [
-      "Test7",
+      "Test9",
       "$hxClasses",
-      "Type"
+      "Type",
+      "Require",
+      "haxe_ds_StringMap",
+      "haxe_IMap"
     ],
     "indexes": [],
     "exports": {
@@ -33,7 +36,8 @@
       6,
       7,
       8,
-      9
+      9,
+      36
     ],
     "exports": {
       "CaseD": true

--- a/tool/test/src/CaseD.hx
+++ b/tool/test/src/CaseD.hx
@@ -1,5 +1,15 @@
 class CaseD {
+	static public var cyclic:Bool;
+
 	static public function init() {
 		trace('CaseC');
+		CycleD.init();
+	}
+}
+
+class CycleD {
+	static public function init() {
+		trace('CycleD');
+		CaseD.cyclic = true;
 	}
 }

--- a/tool/test/src/Test9.hx
+++ b/tool/test/src/Test9.hx
@@ -1,0 +1,8 @@
+// Test9 -> CaseD
+// Module has internal cyclic references (e.g. not orphan), and no reference from entry point
+class Test9 {
+	static function main() {
+		trace('Suite ' + Type.getClassName(Type.resolveClass('Test9')));
+		Bundle.load(CaseD).then(function(_) trace('ok'));
+	}
+}

--- a/tool/test/test-suite.js
+++ b/tool/test/test-suite.js
@@ -5,7 +5,7 @@ const fs = require('fs');
 
 try { fs.mkdirSync('tool/test/bin'); } catch (_) { }
 
-const testClasses = ['Test1', 'Test2', 'Test3', 'Test4', 'Test5', 'Test6', 'Test7', 'Test8'];
+const testClasses = ['Test1', 'Test2', 'Test3', 'Test4', 'Test5', 'Test6', 'Test7', 'Test8', 'Test9'];
 const useLib = { Test4:true, Test5:true };
 
 const suites = [{


### PR DESCRIPTION
It is possible to obtain a fully isolated module, which mean it doesn't get emitted.

Fixed Acorn parsing: simple walker skips the left side of assignment expressions, which means module identifiers were not linked to the call site of `Bundle.load`.

Added test case.
