### PR TITLE
Kha toolchain support

### DIFF
--- a/bin/kha.js
+++ b/bin/kha.js
@@ -1,0 +1,37 @@
+const fs = require('fs');
+const path = require('path');
+const run = require('./run');
+
+//
+// Add in your project's `khafile.js`, before `resolve(project)`:
+//
+//     require('haxe-modular/bin/kha').register(project, callbacks);
+//
+
+module.exports.register = (project, callbacks) => {
+
+	project.addLibrary('modular');
+	project.addDefine('modular_noprocess');
+
+	callbacks.postHaxeCompilation = () => {
+		const args = JSON.parse(fs.readFileSync('build/.temp/split-args.json'));
+
+		const debugMode = remove(args, '-debug');
+		const debugSourceMap = remove(args,  '-debugmap');
+		const dump = remove(args, '-dump');
+		const cjsMode = true;
+
+		const input = args[0];
+		const output = args[1];
+		const modules = args.slice(2);
+
+		run(input, output, modules, debugMode, cjsMode, debugSourceMap, dump);
+	}
+}
+
+function remove(a, v) {
+	const i = a.indexOf(v);
+	if (i < 0) return false;
+	a.splice(i, 1);
+	return true;
+}

--- a/bin/kha.js
+++ b/bin/kha.js
@@ -1,16 +1,21 @@
 const fs = require('fs');
-const path = require('path');
 const run = require('./run');
 
 //
 // Add in your project's `khafile.js`, before `resolve(project)`:
 //
-//     require('haxe-modular/bin/kha').register(project, callbacks);
+//     require('haxe-modular/bin/kha').register(platform, project, callbacks);
 //
 
-module.exports.register = (project, callbacks) => {
+module.exports.register = (platform, project, callbacks) => {
 
 	project.addLibrary('modular');
+
+	if (platform != 'html5') { // 'debug-html5' is an electron target at the moment
+		project.addDefine('modular_stub');
+		return;
+	}
+
 	project.addDefine('modular_noprocess');
 
 	callbacks.postHaxeCompilation = () => {
@@ -19,7 +24,7 @@ module.exports.register = (project, callbacks) => {
 		const debugMode = remove(args, '-debug');
 		const debugSourceMap = remove(args,  '-debugmap');
 		const dump = remove(args, '-dump');
-		const cjsMode = true;
+		const cjsMode = false;
 
 		const input = args[0];
 		const output = args[1];

--- a/bin/run.js
+++ b/bin/run.js
@@ -1,0 +1,43 @@
+const fs = require('fs');
+const path = require('path');
+const hooks = require('./hooks');
+const split = require('../tool/bin/split');
+
+module.exports = function(input, output, modules, debugMode, cjsMode, debugSourceMap, dump) {
+	const t0 = new Date().getTime();
+	const graphHook = hooks.getGraphHooks();
+	const result = split.run(input, output, modules, debugMode, cjsMode, debugSourceMap, dump, graphHook);
+
+	for (file of result) {
+		if (!file || !file.source) continue;
+		if (file.map) {
+			writeIfChanged(file.map.path, JSON.stringify(file.map.content));
+		}
+		const content = file.map
+			? `${file.source.content}\n//# sourceMappingURL=${path.basename(file.map.path)}`
+			: file.source.content;
+		writeIfChanged(file.source.path, content);
+
+		if (file.debugMap) {
+			writeIfChanged(file.source.path + '.map.html', file.debugMap);
+		}
+	}
+
+	const t1 = new Date().getTime();
+	console.log(`Total process: ${t1 - t0}ms`);
+}
+
+/* UTIL */
+
+function hasChanged(output, content) {
+	if (!fs.existsSync(output)) return true;
+	var original = String(fs.readFileSync(output));
+	return original != content;
+}
+
+function writeIfChanged(output, content) {
+	if (hasChanged(output, content)) {
+		console.log('Write ' + output);
+		fs.writeFileSync(output, content);
+	}
+}

--- a/src/Bundle.hx
+++ b/src/Bundle.hx
@@ -15,6 +15,11 @@ class Bundle
 			case Type.TType(_.get() => t, _):
 				var module = t.module.split('_').join('_$').split('.').join('_');
 				Split.register(module);
+
+				#if modular_stub
+				return macro ({ then: function(cb) { cb($v{module}); }});
+				#else
+
 				var bridge = macro var _ = untyped $i{module} = $p{["$s", module]};
 				#if nodejs
 				var jsModule = './$module';
@@ -34,6 +39,7 @@ class Bundle
 							return id;
 						});
 				}
+				#end
 				#end
 			default:
 				Context.fatalError('Module bundling needs to be provided a module class reference', Context.currentPos());
@@ -63,6 +69,11 @@ class Bundle
 				var module = '$libName=$pattern';
 				var bridge = '${libName}__BRIDGE__';
 				Split.register(module);
+
+				#if modular_stub
+				return macro ({ then: function(cb) { cb($v{libName}); }});
+				#else
+
 				return macro {
 					@:keep Require.module($v{libName})
 						.then(function(id:String) {
@@ -70,6 +81,7 @@ class Bundle
 							return id;
 						});
 				}
+				#end
 
 			default:
 				Context.fatalError('Array of string literals expected', pkgListExpr.pos);

--- a/src/Split.hx
+++ b/src/Split.hx
@@ -13,20 +13,20 @@ class Split
 
 	static public function modules()
 	{
-		// generate in temp directory for processing
-		if (!FileSystem.exists('.temp')) FileSystem.createDirectory('.temp');
-
 		output = absolute(Compiler.getOutput());
         if (!StringTools.endsWith(output, '.js')) return;
 
-		#if modular_noprocess
+		#if (!modular_stub)
+		#if (modular_noprocess)
 		tempOutput = output;
 		#else
 		tempOutput = absolute('.temp/output.js');
 		Compiler.setOutput(tempOutput);
 		#end
 
+		if (!FileSystem.exists('.temp')) FileSystem.createDirectory('.temp');
 		Context.onAfterGenerate(generated);
+		#end
 	}
 
 	static function absolute(path:String)

--- a/src/Split.hx
+++ b/src/Split.hx
@@ -1,7 +1,9 @@
+import haxe.Json;
 import haxe.io.Path;
 import haxe.macro.Compiler;
 import haxe.macro.Context;
 import sys.FileSystem;
+import sys.io.File;
 
 class Split
 {
@@ -15,8 +17,14 @@ class Split
 		if (!FileSystem.exists('.temp')) FileSystem.createDirectory('.temp');
 
 		output = absolute(Compiler.getOutput());
+        if (!StringTools.endsWith(output, '.js')) return;
+
+		#if modular_noprocess
+		tempOutput = output;
+		#else
 		tempOutput = absolute('.temp/output.js');
 		Compiler.setOutput(tempOutput);
+		#end
 
 		Context.onAfterGenerate(generated);
 	}
@@ -63,8 +71,12 @@ class Split
 		];
 		args = args.concat(bundles).concat(options);
 
+		#if modular_noprocess
+		File.saveContent('.temp/split-args.json', Json.stringify(args));
+		#else
 		//Sys.println(cmd + ' ' + args.join(' '));
 		var code = Sys.command(cmd, args);
 		if (code != 0) Sys.exit(code);
+		#end
 	}
 }

--- a/tool/bin/split.js
+++ b/tool/bin/split.js
@@ -1177,6 +1177,8 @@ Parser.prototype = {
 			++_g;
 			var _g1 = node.type;
 			switch(_g1) {
+			case "EmptyStatement":
+				break;
 			case "ExpressionStatement":
 				this.inspectExpression(node.expression,node);
 				break;

--- a/tool/bin/split.js
+++ b/tool/bin/split.js
@@ -1577,20 +1577,14 @@ SourceMap.prototype = {
 			var _g5 = this.source.sources.length;
 			while(_g13 < _g5) {
 				var i3 = _g13++;
-				map.sources[i3] = usedSources[i3] ? this.formatPath(this.source.sources[i3]) : null;
+				map.sources[i3] = usedSources[i3] ? this.source.sources[i3] : "";
 			}
+			map.sourceRoot = this.source.sourceRoot;
 			map.mappings = output;
 			return SM.encode(map);
 		} catch( err ) {
 			console.log("Invalid source-map");
 			return null;
-		}
-	}
-	,formatPath: function(path) {
-		if(path.indexOf("file://") < 0) {
-			return "file://" + path;
-		} else {
-			return path;
 		}
 	}
 	,emitFile: function(output,map) {

--- a/tool/bin/split.js
+++ b/tool/bin/split.js
@@ -1767,7 +1767,7 @@ Bundler.GLOBAL = "typeof window != \"undefined\" ? window : typeof global != \"u
 Bundler.FUNCTION_START = "(function ($hx_exports, $global) { \"use-strict\";\n";
 Bundler.FUNCTION_END = "})(" + "typeof exports != \"undefined\" ? exports : typeof window != \"undefined\" ? window : typeof self != \"undefined\" ? self : this" + ", " + "typeof window != \"undefined\" ? window : typeof global != \"undefined\" ? global : typeof self != \"undefined\" ? self : this" + ");\n";
 Bundler.WP_START = "/* eslint-disable */ \"use strict\"\n";
-Bundler.FRAGMENTS = { MAIN : { EXPORTS : "var $hx_exports = exports, $global = global;\n", SHARED : "var $s = $global.$hx_scope = $global.$hx_scope || {};\n"}, CHILD : { EXPORTS : "var $hx_exports = exports, $global = global;\n", SHARED : "var $s = $global.$hx_scope;\n"}};
+Bundler.FRAGMENTS = { MAIN : { EXPORTS : "var $hx_exports = module.exports, $global = global;\n", SHARED : "var $s = $global.$hx_scope = $global.$hx_scope || {};\n"}, CHILD : { EXPORTS : "var $hx_exports = module.exports, $global = global;\n", SHARED : "var $s = $global.$hx_scope;\n"}};
 Bundler.generateHtml = global.generateHtml;
 SourceMap.SRC_REF = "//# sourceMappingURL=";
 })(typeof exports != "undefined" ? exports : typeof window != "undefined" ? window : typeof self != "undefined" ? self : this);

--- a/tool/bin/split.js
+++ b/tool/bin/split.js
@@ -462,6 +462,13 @@ Bundler.prototype = {
 		if(rawMap.sources.length == 0) {
 			return null;
 		}
+		rawMap.sources = rawMap.sources.map(function(url) {
+			if(url == "") {
+				return null;
+			} else {
+				return url;
+			}
+		});
 		var consumer = new SourceMapConsumer(rawMap);
 		var _g = [];
 		var _g1 = 0;
@@ -470,7 +477,7 @@ Bundler.prototype = {
 			var source = _g2[_g1];
 			++_g1;
 			var tmp;
-			if(source == null) {
+			if(source == null || source == "") {
 				tmp = "";
 			} else {
 				var fileName = source.split("file://").pop();
@@ -478,8 +485,8 @@ Bundler.prototype = {
 			}
 			_g.push(tmp);
 		}
-		var sources = _g;
-		return Bundler.generateHtml(consumer,src,sources);
+		var sourcesContent = _g;
+		return Bundler.generateHtml(consumer,src,sourcesContent);
 	}
 	,emitJS: function(src,bundle,isMain) {
 		this.reporter.start(bundle);

--- a/tool/src/Bundler.hx
+++ b/tool/src/Bundler.hx
@@ -39,11 +39,11 @@ class Bundler
 
 	static var FRAGMENTS = {
 		MAIN: {
-			EXPORTS: "var $hx_exports = exports, $global = global;\n",
+			EXPORTS: "var $hx_exports = module.exports, $global = global;\n",
 			SHARED: "var $s = $global.$hx_scope = $global.$hx_scope || {};\n"
 		},
 		CHILD: {
-			EXPORTS: "var $hx_exports = exports, $global = global;\n",
+			EXPORTS: "var $hx_exports = module.exports, $global = global;\n",
 			SHARED: "var $s = $global.$hx_scope;\n"
 		}
 	}

--- a/tool/src/Bundler.hx
+++ b/tool/src/Bundler.hx
@@ -209,16 +209,18 @@ class Bundler
 	function emitDebugMap(src:String, bundle:Bundle, rawMap:SourceMapFile)
 	{
 		if (rawMap.sources.length == 0) return null;
+		// library doesn't like empty strings
+		rawMap.sources = rawMap.sources.map(function(url) return url == '' ? null : url);
 
 		var consumer = new SourceMapConsumer(rawMap);
-		var sources = [for (source in rawMap.sources) {
-			if (source == null) '';
+		var sourcesContent = [for (source in rawMap.sources) {
+			if (source == null || source == '') '';
 			else {
 				var fileName = source.split('file://').pop();
 				Fs.readFileSync(fileName).toString();
 			}
 		}];
-		return generateHtml(consumer, src, sources);
+		return generateHtml(consumer, src, sourcesContent);
 	}
 
 	function emitJS(src:String, bundle:Bundle, isMain:Bool)

--- a/tool/src/Parser.hx
+++ b/tool/src/Parser.hx
@@ -142,6 +142,8 @@ class Parser
 						inspectExpression(node.consequent.expression, node);
 					else
 						inspectIfStatement(node.test, node);
+				case 'EmptyStatement':
+					// ignore
 				default:
 					trace('WARNING: Unexpected ${node.type}, at character ${node.start}');
 			}

--- a/tool/src/SourceMap.hx
+++ b/tool/src/SourceMap.hx
@@ -108,7 +108,8 @@ class SourceMap
 
 			// set used sources
 			for (i in 0...source.sources.length)
-				map.sources[i] = usedSources[i] ? formatPath(source.sources[i]) : null;
+				map.sources[i] = usedSources[i] ? source.sources[i] : '';
+			map.sourceRoot = source.sourceRoot;
 			map.mappings = output;
 
 			// encode mappings
@@ -118,11 +119,6 @@ class SourceMap
 			trace('Invalid source-map');
 			return null;
 		}
-	}
-
-	function formatPath(path:String)
-	{
-		return path.indexOf('file://') < 0 ? 'file://' + path : path;
 	}
 
 	/**


### PR DESCRIPTION
- Added `-D modular_noprocess` to prevent modular to take control of the compiler's JS output - instead it only emits arguments for haxe-split.
- Added `-D modular_stub` to target non-JS targets with modular (API is inactive).
- Added helpers for Kha to hook in Kha build process.
- Note: splitting is disabled for `debug-html5` because there is no way to detect that the build is for Krom in Kode.
- Finishing the feature requires a way to detect (from the `khafile.js`) that it's an Electron target.
- To try this branch you need to install `haxe-modular` npm from git in the local `node_modules`.

Usage:
```
let project = new Project('Blocks');

project.addAssets('Assets/**');

project.addSources('Sources');

// Add modular library and split hook
require('haxe-modular/bin/kha').register(platform, project, callbacks);

resolve(project);
```