### PR TITLE
Allow to customise the path of required modules

### DIFF
--- a/doc/library-usage.md
+++ b/doc/library-usage.md
@@ -141,14 +141,17 @@ otherwise, calling the function again will attempt to reload the failed script.
 `Require.module(module:String):Promise<String>`
 
 - `module`: the name of the JS file to load (Haxe-JS module or library),
-- returns a Promise providing the name of the loaded module
+- returns a Promise providing the name of the loaded module.
 
-`Require.jsPath`: relative path to JS files (defaults to `./`)
+`Require.basePath`: relative path to JS files (defaults to `./`).
+
+`Require.extension`: file extension (defaults to `.js`), which you can modify
+if you want to add for instance a cache buster.
 
 ## Nodejs
 
 Nodejs is supported, and recognised when `-D nodejs` is set (e.g. when using
 `-lib hxnodejs`); Modular will then emit code specifically for nodejs.
 
-Although the Promise API stays, bundle loading happens *synchronously*; that is it completes
-immediately, while in the browser it will always complete asynchronously.
+Although the Promise API stays, bundle loading happens *synchronously*; that is it
+completes immediately, while in the browser it will always complete asynchronously.

--- a/doc/library-usage.md
+++ b/doc/library-usage.md
@@ -143,9 +143,9 @@ otherwise, calling the function again will attempt to reload the failed script.
 - `module`: the name of the JS file to load (Haxe-JS module or library),
 - returns a Promise providing the name of the loaded module.
 
-`Require.basePath`: relative path to JS files (defaults to `./`).
+`Require.jsPath`: relative path to JS files (defaults to `./`).
 
-`Require.extension`: file extension (defaults to `.js`), which you can modify
+`Require.jsExt`: file extension (defaults to `.js`), which you can modify
 if you want to add for instance a cache buster.
 
 ## Nodejs

--- a/src/Require.hx
+++ b/src/Require.hx
@@ -4,8 +4,8 @@ import haxe.macro.Expr;
 class Require
 {
 	#if (!macro && !webpack)
-	static public var basePath = './';
-	static public var extension = '.js';
+	static public var jsPath = './';
+	static public var jsExt = '.js';
 
 	static var loaded:Map<String, js.Promise<String>> = new Map();
 	static var handlers:Map<String, String -> Void> = new Map();
@@ -50,7 +50,7 @@ class Require
 			script = doc.createScriptElement();
 			script.onload = resourceLoaded;
 			script.onerror = resourceFailed;
-			script.src = basePath + name + extension;
+			script.src = jsPath + name + jsExt;
 			doc.body.appendChild(script);
 		});
 

--- a/src/Require.hx
+++ b/src/Require.hx
@@ -4,7 +4,8 @@ import haxe.macro.Expr;
 class Require
 {
 	#if (!macro && !webpack)
-	static public var jsPath = './';
+	static public var basePath = './';
+	static public var extension = '.js';
 
 	static var loaded:Map<String, js.Promise<String>> = new Map();
 	static var handlers:Map<String, String -> Void> = new Map();
@@ -49,7 +50,7 @@ class Require
 			script = doc.createScriptElement();
 			script.onload = resourceLoaded;
 			script.onerror = resourceFailed;
-			script.src = jsPath + name + '.js';
+			script.src = basePath + name + extension;
 			doc.body.appendChild(script);
 		});
 


### PR DESCRIPTION
Added `Require.jsExt = '.js'`, allowing to add a cache buster after the extension.