### PR TITLE
Size optimisation

### DIFF
--- a/tool/src/HxSplit.hx
+++ b/tool/src/HxSplit.hx
@@ -13,7 +13,7 @@ class HxSplit
 	{
 		// parse input
 		var src = Fs.readFileSync(input).toString();
-		var parser = new Parser(src, debugMode);
+		var parser = new Parser(src, debugMode, commonjs);
 		var sourceMap = debugMode ? new SourceMap(input, src) : null;
 
 		// external hook

--- a/tool/src/MinifyId.hx
+++ b/tool/src/MinifyId.hx
@@ -1,0 +1,43 @@
+import haxe.DynamicAccess;
+
+class MinifyId
+{
+	static var BASE_16 = 'abcdefghijklmnop'.split('');
+
+	var map:DynamicAccess<String> = {};
+	var index:Int = 0;
+
+	public function new()
+	{
+	}
+
+	/**
+	 * Preserve an id from minification
+	 */
+	public function set(id:String)
+	{
+		map.set(id, id);
+	}
+
+	/**
+	 * return a minified id
+	 */
+	public function get(id:String)
+	{
+		if (id.length <= 2) return id;
+		var min = map.get(id);
+		if (min == null) {
+			var B16 = BASE_16;
+			var i = index++;
+			min = '';
+			while (i > 0xf) {
+				var add = i & 0xf;
+				i = (i >> 4) - 1;
+				min = B16[add] + min;
+			}
+			min = B16[i] + min;
+			map.set(id, min);
+		}
+		return min;
+	}
+}

--- a/tool/src/Parser.hx
+++ b/tool/src/Parser.hx
@@ -20,14 +20,14 @@ class Parser
 
 	var types:DynamicAccess<Array<AstNode>>;
 
-	public function new(src:String, withLocation:Bool)
+	public function new(src:String, withLocation:Bool, commonjs:Bool)
 	{
 		var t0 = Date.now().getTime();
 		processInput(src, withLocation);
 		var t1 = Date.now().getTime();
 		trace('Parsed in: ${t1 - t0}ms');
 
-		buildGraph();
+		buildGraph(commonjs);
 		var t2 = Date.now().getTime();
 		trace('AST processed in: ${t2 - t1}ms');
 	}
@@ -39,15 +39,21 @@ class Parser
 		walkProgram(program);
 	}
 
-	function buildGraph()
+	function buildGraph(commonjs:Bool)
 	{
 		var g = new Graph({ directed: true, compound:true });
 		var cpt = 0;
 		var refs = 0;
-		for (t in types.keys())
-		{
+		for (t in types.keys()) {
 			cpt++;
 			g.setNode(t, t);
+		}
+
+		if (!commonjs) {
+			// require stub is generated in web entry point
+			types.set('require', []);
+			g.setNode('require', 'require');
+			g.setEdge(mainModule, 'require');
 		}
 
 		for (t in types.keys())

--- a/tool/test/expect/web-debug-closure-testinterop.json
+++ b/tool/test/expect/web-debug-closure-testinterop.json
@@ -20,7 +20,8 @@
       "haxe_ds_StringMap",
       "haxe_io_Error",
       "js_Boot",
-      "js__$Boot_HaxeError"
+      "js__$Boot_HaxeError",
+      "require"
     ],
     "exports": {
       "js_Boot": true,
@@ -30,7 +31,8 @@
       "js__$Boot_HaxeError": true,
       "haxe_io_Error": true,
       "Std": true,
-      "$estr": true
+      "$estr": true,
+      "require": true
     },
     "shared": {
       "CaseInterop": true
@@ -66,7 +68,8 @@
       "js__$Boot_HaxeError": true,
       "haxe_io_Error": true,
       "Std": true,
-      "$estr": true
+      "$estr": true,
+      "require": true
     }
   },
   {

--- a/tool/test/expect/web-debug-test1.json
+++ b/tool/test/expect/web-debug-test1.json
@@ -16,7 +16,8 @@
       "haxe_IMap",
       "haxe_Timer",
       "haxe_ds_StringMap",
-      "js_Boot"
+      "js_Boot",
+      "require"
     ],
     "exports": {
       "DepAB": true,

--- a/tool/test/expect/web-debug-test2.json
+++ b/tool/test/expect/web-debug-test2.json
@@ -16,7 +16,8 @@
       "haxe_IMap",
       "haxe_Timer",
       "haxe_ds_StringMap",
-      "js_Boot"
+      "js_Boot",
+      "require"
     ],
     "exports": {
       "DepAB": true,

--- a/tool/test/expect/web-debug-test3.json
+++ b/tool/test/expect/web-debug-test3.json
@@ -14,7 +14,8 @@
       "haxe_IMap",
       "haxe_Timer",
       "haxe_ds_StringMap",
-      "js_Boot"
+      "js_Boot",
+      "require"
     ],
     "exports": {
       "Require": true,

--- a/tool/test/expect/web-debug-test4.json
+++ b/tool/test/expect/web-debug-test4.json
@@ -18,7 +18,8 @@
       "haxe_IMap",
       "haxe_Timer",
       "haxe_ds_StringMap",
-      "js_Boot"
+      "js_Boot",
+      "require"
     ],
     "exports": {
       "DepAB": true,

--- a/tool/test/expect/web-debug-test5.json
+++ b/tool/test/expect/web-debug-test5.json
@@ -18,7 +18,8 @@
       "haxe_IMap",
       "haxe_Timer",
       "haxe_ds_StringMap",
-      "js_Boot"
+      "js_Boot",
+      "require"
     ],
     "exports": {
       "$hxClasses": true,

--- a/tool/test/expect/web-debug-test6.json
+++ b/tool/test/expect/web-debug-test6.json
@@ -15,7 +15,8 @@
       "haxe_Timer",
       "haxe_ds_StringMap",
       "js_Boot",
-      "js__$Boot_HaxeError"
+      "js__$Boot_HaxeError",
+      "require"
     ],
     "exports": {
       "$hxClasses": true

--- a/tool/test/expect/web-debug-test7.json
+++ b/tool/test/expect/web-debug-test7.json
@@ -12,7 +12,8 @@
       "haxe_IMap",
       "haxe_Timer",
       "haxe_ds_StringMap",
-      "js_Boot"
+      "js_Boot",
+      "require"
     ],
     "exports": {
       "$hxClasses": true

--- a/tool/test/expect/web-debug-test8.json
+++ b/tool/test/expect/web-debug-test8.json
@@ -6,7 +6,8 @@
     "nodes": [
       "$hxClasses",
       "Test8",
-      "Type"
+      "Type",
+      "require"
     ],
     "exports": {},
     "shared": {},

--- a/tool/test/expect/web-debug-test9.json
+++ b/tool/test/expect/web-debug-test9.json
@@ -12,7 +12,8 @@
       "haxe_IMap",
       "haxe_Timer",
       "haxe_ds_StringMap",
-      "js_Boot"
+      "js_Boot",
+      "require"
     ],
     "exports": {
       "$hxClasses": true

--- a/tool/test/expect/web-debug-testinterop.json
+++ b/tool/test/expect/web-debug-testinterop.json
@@ -20,7 +20,8 @@
       "haxe_ds_StringMap",
       "haxe_io_Error",
       "js_Boot",
-      "js__$Boot_HaxeError"
+      "js__$Boot_HaxeError",
+      "require"
     ],
     "exports": {
       "js_Boot": true,
@@ -30,7 +31,8 @@
       "js__$Boot_HaxeError": true,
       "haxe_io_Error": true,
       "Std": true,
-      "$estr": true
+      "$estr": true,
+      "require": true
     },
     "shared": {
       "CaseInterop": true
@@ -66,7 +68,8 @@
       "js__$Boot_HaxeError": true,
       "haxe_io_Error": true,
       "Std": true,
-      "$estr": true
+      "$estr": true,
+      "require": true
     }
   },
   {

--- a/tool/test/expect/web-release-closure-testinterop.json
+++ b/tool/test/expect/web-release-closure-testinterop.json
@@ -18,7 +18,8 @@
       "haxe_IMap",
       "haxe_ds_StringMap",
       "js_Boot",
-      "js__$Boot_HaxeError"
+      "js__$Boot_HaxeError",
+      "require"
     ],
     "exports": {
       "js_Boot": true,
@@ -27,7 +28,8 @@
       "Require": true,
       "js__$Boot_HaxeError": true,
       "$estr": true,
-      "Std": true
+      "Std": true,
+      "require": true
     },
     "shared": {
       "CaseInterop": true
@@ -63,7 +65,8 @@
       "Require": true,
       "js__$Boot_HaxeError": true,
       "$estr": true,
-      "Std": true
+      "Std": true,
+      "require": true
     }
   },
   {

--- a/tool/test/expect/web-release-test1.json
+++ b/tool/test/expect/web-release-test1.json
@@ -13,7 +13,8 @@
       "Type",
       "haxe_IMap",
       "haxe_ds_StringMap",
-      "js_Boot"
+      "js_Boot",
+      "require"
     ],
     "exports": {
       "DepAB": true,

--- a/tool/test/expect/web-release-test2.json
+++ b/tool/test/expect/web-release-test2.json
@@ -13,7 +13,8 @@
       "Type",
       "haxe_IMap",
       "haxe_ds_StringMap",
-      "js_Boot"
+      "js_Boot",
+      "require"
     ],
     "exports": {
       "DepAB": true,

--- a/tool/test/expect/web-release-test3.json
+++ b/tool/test/expect/web-release-test3.json
@@ -11,7 +11,8 @@
       "Test3",
       "Type",
       "haxe_IMap",
-      "haxe_ds_StringMap"
+      "haxe_ds_StringMap",
+      "require"
     ],
     "exports": {
       "Require": true,

--- a/tool/test/expect/web-release-test4.json
+++ b/tool/test/expect/web-release-test4.json
@@ -15,7 +15,8 @@
       "Type",
       "haxe_IMap",
       "haxe_ds_StringMap",
-      "js_Boot"
+      "js_Boot",
+      "require"
     ],
     "exports": {
       "DepAB": true,

--- a/tool/test/expect/web-release-test5.json
+++ b/tool/test/expect/web-release-test5.json
@@ -15,7 +15,8 @@
       "Type",
       "haxe_IMap",
       "haxe_ds_StringMap",
-      "js_Boot"
+      "js_Boot",
+      "require"
     ],
     "exports": {
       "$hxClasses": true,

--- a/tool/test/expect/web-release-test6.json
+++ b/tool/test/expect/web-release-test6.json
@@ -12,7 +12,8 @@
       "Type",
       "haxe_IMap",
       "haxe_ds_StringMap",
-      "js__$Boot_HaxeError"
+      "js__$Boot_HaxeError",
+      "require"
     ],
     "exports": {
       "$hxClasses": true

--- a/tool/test/expect/web-release-test7.json
+++ b/tool/test/expect/web-release-test7.json
@@ -9,7 +9,8 @@
       "Test7",
       "Type",
       "haxe_IMap",
-      "haxe_ds_StringMap"
+      "haxe_ds_StringMap",
+      "require"
     ],
     "exports": {
       "$hxClasses": true

--- a/tool/test/expect/web-release-test8.json
+++ b/tool/test/expect/web-release-test8.json
@@ -6,7 +6,8 @@
     "nodes": [
       "$hxClasses",
       "Test8",
-      "Type"
+      "Type",
+      "require"
     ],
     "exports": {},
     "shared": {},

--- a/tool/test/expect/web-release-test9.json
+++ b/tool/test/expect/web-release-test9.json
@@ -9,7 +9,8 @@
       "Test9",
       "Type",
       "haxe_IMap",
-      "haxe_ds_StringMap"
+      "haxe_ds_StringMap",
+      "require"
     ],
     "exports": {
       "$hxClasses": true

--- a/tool/test/expect/web-release-testinterop.json
+++ b/tool/test/expect/web-release-testinterop.json
@@ -18,7 +18,8 @@
       "haxe_IMap",
       "haxe_ds_StringMap",
       "js_Boot",
-      "js__$Boot_HaxeError"
+      "js__$Boot_HaxeError",
+      "require"
     ],
     "exports": {
       "js_Boot": true,
@@ -27,7 +28,8 @@
       "Require": true,
       "js__$Boot_HaxeError": true,
       "$estr": true,
-      "Std": true
+      "Std": true,
+      "require": true
     },
     "shared": {
       "CaseInterop": true
@@ -63,7 +65,8 @@
       "Require": true,
       "js__$Boot_HaxeError": true,
       "$estr": true,
-      "Std": true
+      "Std": true,
+      "require": true
     }
   },
   {

--- a/tool/test/src/CaseInterop.hx
+++ b/tool/test/src/CaseInterop.hx
@@ -13,6 +13,7 @@ class CaseInterop {
 			var d = new js.html.DataView(new js.html.ArrayBuffer(2));
 			// verify sharing of $estr
 			var estr = untyped __js__("$estr");
+			var m = js.Lib.require('foo');
 			#end
 		});
 	}


### PR DESCRIPTION
- compress `$s.xxx` shared variables,
- share `require` stub with modules instead of duplicating it in every module.

Instead of having:
```javascript
// shared classes
$s.MyClass = MyClass; $s.OtherClass = OtherClass; ...
// imported class
var MyClass = $s.MyClass, OtherClass = $s.OtherClass, ...
```
The shared variables are compressed into:
```javascript
// shared classes
$s.a = MyClass; $s.b = OtherClass; ...
// imported classes
var MyClass = $s.a, OtherClass = $s.b, ...
```
Exceptions:
- class names of 2 characters or less (eg. `class R`),
- bundle entry point (eg. `MyClass` when `Bundle.load(MyClass)`)
