### PR TITLE
Libs optimisation

### DIFF
--- a/src/Bundle.hx
+++ b/src/Bundle.hx
@@ -64,7 +64,7 @@ class Bundle
 			case EArrayDecl(values):
 				var pattern = values
 					.map(getString)
-					.map(function(v:String) return v.split('_').join('_$').split('.').join('_') + '_')
+					.map(formatMatch)
 					.join('|');
 				var module = '$libName=$pattern';
 				var bridge = '${libName}__BRIDGE__';
@@ -88,4 +88,12 @@ class Bundle
 		}
 		return macro {};
 	}
+
+	#if macro
+	static function formatMatch(s:String)
+	{
+		var m = s.split('_').join('_$').split('.').join('_');
+		return ~/_[A-Z]/.match(m) ? m : m += '_';
+	}
+	#end
 }

--- a/tool/src/Extractor.hx
+++ b/tool/src/Extractor.hx
@@ -14,7 +14,7 @@ typedef Bundle = {
 	imports:DynamicAccess<Bool>
 }
 
-typedef LibTest = { test:EReg, roots:DynamicAccess<Bool>, bundle:Bundle };
+typedef LibTest = { test:Array<String>, roots:DynamicAccess<Bool>, bundle:Bundle };
 
 class Extractor
 {
@@ -32,7 +32,7 @@ class Extractor
 	var mainImports:Array<String>;
 	var mainExports:Array<String>;
 	var libsNodes:Array<String>;
-	var libMap:DynamicAccess<String>;
+	var libMap:DynamicAccess<LibTest>;
 	var moduleTest:DynamicAccess<Bool>;
 	var parenting:Graph;
 	var moduleMap:DynamicAccess<Bundle>;
@@ -185,7 +185,7 @@ class Extractor
 				continue;
 			}
 			// reached lib
-			if (isInLib(bundle, node, libTest)) {
+			if (isInLib(node, libTest)) {
 				continue;
 			}
 			// deduplicate
@@ -254,13 +254,12 @@ class Extractor
 		return best;
 	}
 
-	function isInLib(bundle:Bundle, node:String, libTest:Array<LibTest>)
+	inline function isInLib(node:String, libTest:Array<LibTest>)
 	{
-		for (lib in libTest) {
-			if (lib.test.match(node)) {
-				lib.roots.set(node, true);
-				return true;
-			}
+		var lib = libMap.get(node);
+		if (lib != null && libTest.indexOf(lib) >= 0) {
+			lib.roots.set(node, true);
+			return true;
 		}
 		return false;
 	}
@@ -315,23 +314,44 @@ class Extractor
 
 	function expandLibs()
 	{
+		libMap = {};
 		var libTest:Array<LibTest> = [];
-		for (module in modules) {
+		var allNodes = parser.graph.nodes();
+		for (i in 0...modules.length) {
+			var module = modules[i];
 			if (module.indexOf('=') > 0) {
-				libTest.push(resolveLib(module));
+				var lib = resolveLib(module);
+				mapLibTypes(allNodes, lib);
+				libTest.push(lib);
 			}
 		}
 		return libTest;
 	}
 
-	function resolveLib(name:String)
+	function mapLibTypes(allNodes:Array<String>, lib:LibTest)
+	{
+		// match each node with owning lib
+		var test = lib.test;
+		var n = test.length;
+		for (i in 0...allNodes.length) {
+			var node = allNodes[i];
+			for (j in 0...n) {
+				// use JS native `startsWith`
+				if (untyped node.startsWith(test[j])) {
+					libMap.set(node, lib);
+					break;
+				}
+			}
+		}
+	}
+
+	function resolveLib(name:String):LibTest
 	{
 		// libname=pattern
 		var parts = name.split('=');
 		var newName = parts[0];
-		var test = new EReg('^${parts[1]}', '');
 		return {
-			test: test,
+			test: parts[1].split('|'),
 			roots: ({} :DynamicAccess<Bool>),
 			bundle: createBundle(newName, true)
 		};

--- a/tool/test/expect/node-debug-test5.json
+++ b/tool/test/expect/node-debug-test5.json
@@ -25,6 +25,7 @@
     },
     "shared": {
       "lib_Lib2": true,
+      "a_$b_C_$_$d": true,
       "CaseA": true,
       "CaseB": true
     },
@@ -35,12 +36,14 @@
     "isLib": true,
     "name": "lib",
     "nodes": [
+      "a_$b_C_$_$d",
       "lib_DepLib",
       "lib_Lib",
       "lib_Lib2"
     ],
     "exports": {
       "lib_Lib2": true,
+      "a_$b_C_$_$d": true,
       "lib_Lib": true
     },
     "shared": {},

--- a/tool/test/expect/node-release-test5.json
+++ b/tool/test/expect/node-release-test5.json
@@ -24,6 +24,7 @@
     },
     "shared": {
       "lib_Lib2": true,
+      "a_$b_C_$_$d": true,
       "CaseA": true,
       "CaseB": true
     },
@@ -34,12 +35,14 @@
     "isLib": true,
     "name": "lib",
     "nodes": [
+      "a_$b_C_$_$d",
       "lib_DepLib",
       "lib_Lib",
       "lib_Lib2"
     ],
     "exports": {
       "lib_Lib2": true,
+      "a_$b_C_$_$d": true,
       "lib_Lib": true
     },
     "shared": {},

--- a/tool/test/expect/web-debug-test5.json
+++ b/tool/test/expect/web-debug-test5.json
@@ -28,6 +28,7 @@
     },
     "shared": {
       "lib_Lib2": true,
+      "a_$b_C_$_$d": true,
       "CaseA": true,
       "CaseB": true
     },
@@ -38,12 +39,14 @@
     "isLib": true,
     "name": "lib",
     "nodes": [
+      "a_$b_C_$_$d",
       "lib_DepLib",
       "lib_Lib",
       "lib_Lib2"
     ],
     "exports": {
       "lib_Lib2": true,
+      "a_$b_C_$_$d": true,
       "lib_Lib": true
     },
     "shared": {},

--- a/tool/test/expect/web-release-test5.json
+++ b/tool/test/expect/web-release-test5.json
@@ -25,6 +25,7 @@
     },
     "shared": {
       "lib_Lib2": true,
+      "a_$b_C_$_$d": true,
       "CaseA": true,
       "CaseB": true
     },
@@ -35,12 +36,14 @@
     "isLib": true,
     "name": "lib",
     "nodes": [
+      "a_$b_C_$_$d",
       "lib_DepLib",
       "lib_Lib",
       "lib_Lib2"
     ],
     "exports": {
       "lib_Lib2": true,
+      "a_$b_C_$_$d": true,
       "lib_Lib": true
     },
     "shared": {},

--- a/tool/test/src/Test5.hx
+++ b/tool/test/src/Test5.hx
@@ -4,8 +4,9 @@ class Test5 {
 	static function main() {
 		trace('Suite ' + Type.getClassName(Type.resolveClass('Test5')));
 		new DepMain();
-		Bundle.loadLib('lib', ['lib']).then(function(_) {
+		Bundle.loadLib('lib', ['lib', 'a_b.C__d']).then(function(_) {
 			new lib.Lib.Lib2();
+			new a_b.C__d();
 			Bundle.load(CaseA).then(function(_) new CaseA() );
 			Bundle.load(CaseB).then(function(_) new CaseB() );
 		});


### PR DESCRIPTION
- Use string `startsWith` to match nodes with libs instead of EReg,
- Pre-evaluate nodes against libs instead of matching them during graph walking,
- Now support both a package or class name (also matched with `startsWith`).