### PR TITLE
Add check for -D js-classic

### DIFF
--- a/src/Bundle.hx
+++ b/src/Bundle.hx
@@ -2,6 +2,10 @@ import haxe.macro.Context;
 import haxe.macro.Expr;
 import haxe.macro.Type;
 
+#if (js_classic)
+	#error 'haxe-modular doesn\'t work with -D js-classic'
+#end
+
 class Bundle
 {
 	/**


### PR DESCRIPTION
I ran into this while trying to port a project that used `-D js-classic` to use `haxe-modular` -- I assume that this flavor of output JS is simply not supported?

This PR gives a nice compile-time error to that effect. Without this PR, I got this confusing error during the split phase:

```
node_modules/haxe-modular/tool/bin/split.js:886
		var _g = block.type;
		              ^

TypeError: Cannot read property 'type' of undefined
    at Object.walkRootFunction (node_modules/haxe-modular/tool/bin/split.js:886:17)
    at Object.walkRootExpression (node_modules/haxe-modular/tool/bin/split.js:879:9)
    at Object.walkProgram (node_modules/haxe-modular/tool/bin/split.js:871:9)
    at Object.processInput (node_modules/haxe-modular/tool/bin/split.js:819:8)
    at Object.Parser (node_modules/haxe-modular/tool/bin/split.js:809:7)
    at Object.Main.run.$hx_exports.run [as run] (node_modules/haxe-modular/tool/bin/split.js:760:15)
    at Object.<anonymous> (node_modules/haxe-modular/bin/cmd.js:27:22)
    at Module._compile (module.js:570:32)
    at Object.Module._extensions..js (module.js:579:10)
    at Module.load (module.js:487:32)
```