### PR TITLE
Allow JS reserved keywords

### DIFF
--- a/tool/bin/split.js
+++ b/tool/bin/split.js
@@ -1141,7 +1141,10 @@ var Parser = function(src,withLocation,commonjs) {
 Parser.__name__ = true;
 Parser.prototype = {
 	processInput: function(src,withLocation) {
-		var options = withLocation ? { ecmaVersion : 5, locations : true} : { ecmaVersion : 5};
+		var options = { ecmaVersion : 5, allowReserved : true};
+		if(withLocation) {
+			options.locations = true;
+		}
 		var program = acorn_Acorn.parse(src,options);
 		this.walkProgram(program);
 	}

--- a/tool/src/Parser.hx
+++ b/tool/src/Parser.hx
@@ -34,7 +34,8 @@ class Parser
 
 	function processInput(src:String, withLocation:Bool)
 	{
-		var options:AcornOptions = withLocation ? { ecmaVersion:5, locations:true } : { ecmaVersion:5 };
+		var options:AcornOptions = { ecmaVersion: 5, allowReserved: true };
+		if (withLocation) options.locations = true;
 		var program = Acorn.parse(src, options);
 		walkProgram(program);
 	}

--- a/tool/test/test-suite.js
+++ b/tool/test/test-suite.js
@@ -2,6 +2,7 @@
 
 const exec = require('child_process').exec;
 const fs = require('fs');
+const t0 = new Date().getTime();
 
 try { fs.mkdirSync('tool/test/bin'); } catch (_) { }
 
@@ -60,6 +61,7 @@ function exitWithResult() {
 		console.log('One or more test case has failed:', hasFailedCase);
 		process.exit(hasFailedCase);
 	}
+	console.log('Completed in', ((new Date().getTime() - t0) / 1000).toFixed(1) + 's');
 }
 
 function runInterop() {


### PR DESCRIPTION
Loosen Acorn.js parser to allow using `import` for the Webpack loader; could also be faster to process, and Webpack 4 warns that `System.import` is deprecated.