### PR TITLE
Support Object methods in static __init__

### DIFF
--- a/tool/test/expect/node-debug-test10.json
+++ b/tool/test/expect/node-debug-test10.json
@@ -10,8 +10,8 @@
       "Type"
     ],
     "exports": {
-      "$hxClasses": true,
-      "Test10": true
+      "Test10": true,
+      "$hxClasses": true
     },
     "shared": {
       "CaseE": true
@@ -32,8 +32,8 @@
       "DepE": true
     },
     "imports": {
-      "$hxClasses": true,
-      "Test10": true
+      "Test10": true,
+      "$hxClasses": true
     }
   },
   {

--- a/tool/test/expect/node-debug-test11.json
+++ b/tool/test/expect/node-debug-test11.json
@@ -1,0 +1,36 @@
+[
+  {
+    "isMain": true,
+    "isLib": false,
+    "name": "Test11",
+    "nodes": [
+      "$hxClasses",
+      "Test11",
+      "Type"
+    ],
+    "exports": {
+      "$hxClasses": true
+    },
+    "shared": {
+      "CaseF": true
+    },
+    "imports": {}
+  },
+  {
+    "isMain": false,
+    "isLib": false,
+    "name": "CaseF",
+    "nodes": [
+      "$extend",
+      "CaseF",
+      "js__$Boot_HaxeError"
+    ],
+    "exports": {
+      "CaseF": true
+    },
+    "shared": {},
+    "imports": {
+      "$hxClasses": true
+    }
+  }
+]

--- a/tool/test/expect/node-release-test10.json
+++ b/tool/test/expect/node-release-test10.json
@@ -10,8 +10,8 @@
       "Type"
     ],
     "exports": {
-      "$hxClasses": true,
-      "Test10": true
+      "Test10": true,
+      "$hxClasses": true
     },
     "shared": {
       "CaseE": true
@@ -32,8 +32,8 @@
       "DepE": true
     },
     "imports": {
-      "$hxClasses": true,
-      "Test10": true
+      "Test10": true,
+      "$hxClasses": true
     }
   },
   {

--- a/tool/test/expect/node-release-test11.json
+++ b/tool/test/expect/node-release-test11.json
@@ -1,0 +1,36 @@
+[
+  {
+    "isMain": true,
+    "isLib": false,
+    "name": "Test11",
+    "nodes": [
+      "$hxClasses",
+      "Test11",
+      "Type"
+    ],
+    "exports": {
+      "$hxClasses": true
+    },
+    "shared": {
+      "CaseF": true
+    },
+    "imports": {}
+  },
+  {
+    "isMain": false,
+    "isLib": false,
+    "name": "CaseF",
+    "nodes": [
+      "$extend",
+      "CaseF",
+      "js__$Boot_HaxeError"
+    ],
+    "exports": {
+      "CaseF": true
+    },
+    "shared": {},
+    "imports": {
+      "$hxClasses": true
+    }
+  }
+]

--- a/tool/test/expect/web-debug-test10.json
+++ b/tool/test/expect/web-debug-test10.json
@@ -17,9 +17,9 @@
       "require"
     ],
     "exports": {
-      "$hxClasses": true,
       "Test10": true,
-      "Require": true
+      "Require": true,
+      "$hxClasses": true
     },
     "shared": {
       "CaseE": true
@@ -40,9 +40,9 @@
       "DepE": true
     },
     "imports": {
-      "$hxClasses": true,
       "Test10": true,
-      "Require": true
+      "Require": true,
+      "$hxClasses": true
     }
   },
   {

--- a/tool/test/expect/web-debug-test11.json
+++ b/tool/test/expect/web-debug-test11.json
@@ -1,0 +1,43 @@
+[
+  {
+    "isMain": true,
+    "isLib": false,
+    "name": "Test11",
+    "nodes": [
+      "$hxClasses",
+      "Require",
+      "Std",
+      "Test11",
+      "Type",
+      "haxe_IMap",
+      "haxe_Timer",
+      "haxe_ds_StringMap",
+      "js_Boot",
+      "require"
+    ],
+    "exports": {
+      "$hxClasses": true
+    },
+    "shared": {
+      "CaseF": true
+    },
+    "imports": {}
+  },
+  {
+    "isMain": false,
+    "isLib": false,
+    "name": "CaseF",
+    "nodes": [
+      "$extend",
+      "CaseF",
+      "js__$Boot_HaxeError"
+    ],
+    "exports": {
+      "CaseF": true
+    },
+    "shared": {},
+    "imports": {
+      "$hxClasses": true
+    }
+  }
+]

--- a/tool/test/expect/web-release-test10.json
+++ b/tool/test/expect/web-release-test10.json
@@ -14,9 +14,9 @@
       "require"
     ],
     "exports": {
-      "$hxClasses": true,
       "Test10": true,
-      "Require": true
+      "Require": true,
+      "$hxClasses": true
     },
     "shared": {
       "CaseE": true
@@ -37,9 +37,9 @@
       "DepE": true
     },
     "imports": {
-      "$hxClasses": true,
       "Test10": true,
-      "Require": true
+      "Require": true,
+      "$hxClasses": true
     }
   },
   {

--- a/tool/test/expect/web-release-test11.json
+++ b/tool/test/expect/web-release-test11.json
@@ -1,0 +1,40 @@
+[
+  {
+    "isMain": true,
+    "isLib": false,
+    "name": "Test11",
+    "nodes": [
+      "$hxClasses",
+      "Require",
+      "Test11",
+      "Type",
+      "haxe_IMap",
+      "haxe_ds_StringMap",
+      "require"
+    ],
+    "exports": {
+      "$hxClasses": true
+    },
+    "shared": {
+      "CaseF": true
+    },
+    "imports": {}
+  },
+  {
+    "isMain": false,
+    "isLib": false,
+    "name": "CaseF",
+    "nodes": [
+      "$extend",
+      "CaseF",
+      "js__$Boot_HaxeError"
+    ],
+    "exports": {
+      "CaseF": true
+    },
+    "shared": {},
+    "imports": {
+      "$hxClasses": true
+    }
+  }
+]

--- a/tool/test/src/CaseE.hx
+++ b/tool/test/src/CaseE.hx
@@ -1,6 +1,6 @@
 class CaseE {
 	static public var SECRET = 'secret';
-	static public function init() {
+	public function new() {
 		trace('CaseE');
 		trace(Test10.SECRET);
 		Bundle.load(DepE).then(function(_) new DepE() );

--- a/tool/test/src/CaseF.hx
+++ b/tool/test/src/CaseF.hx
@@ -1,0 +1,22 @@
+class CaseF {
+	static var b:Bool;
+	var s:String;
+
+	public function new() {
+		trace('CaseF');
+		if (b != true) throw 'Wrapped not called';
+		if (s != 'direct') throw 'Getter not setup: ' + s;
+	}
+
+	static function wrapped() {
+		b = true;
+	}
+
+	static function __init__() {
+		wrapped();
+
+		untyped Object.defineProperty((cast CaseF).prototype, 's', {
+			get: function() return 'getter'
+		});
+	}
+}

--- a/tool/test/src/Test10.hx
+++ b/tool/test/src/Test10.hx
@@ -4,6 +4,6 @@ class Test10 {
 	static public var SECRET = 'secret';
 	static function main() {
 		trace('Suite ' + Type.getClassName(Type.resolveClass('Test10')));
-		Bundle.load(CaseE).then(function(_) trace('ok'));
+		Bundle.load(CaseE).then(function(_) new CaseE());
 	}
 }

--- a/tool/test/src/Test11.hx
+++ b/tool/test/src/Test11.hx
@@ -1,0 +1,8 @@
+// Test11 -> CaseF
+// Static __init__
+class Test11 {
+	static function main() {
+		trace('Suite ' + Type.getClassName(Type.resolveClass('Test11')));
+		Bundle.load(CaseF).then(function(_) new CaseF());
+	}
+}

--- a/tool/test/test-suite.js
+++ b/tool/test/test-suite.js
@@ -6,7 +6,7 @@ const t0 = new Date().getTime();
 
 try { fs.mkdirSync('tool/test/bin'); } catch (_) { }
 
-const testClasses = ['Test1', 'Test2', 'Test3', 'Test4', 'Test5', 'Test6', 'Test7', 'Test8', 'Test9', 'Test10'];
+const testClasses = ['Test1', 'Test2', 'Test3', 'Test4', 'Test5', 'Test6', 'Test7', 'Test8', 'Test9', 'Test10', 'Test11'];
 const useLib = { Test4:true, Test5:true };
 
 const suites = [{


### PR DESCRIPTION
Fixes #37 : Using `Object.defineProperty` / `Object.defineProperties` in a static `__init__` function breaks Modular because the code isn't attributed to the type.