### PR TITLE
Change character which was used as delimiter for multiple package spl…

### DIFF
--- a/src/Bundle.hx
+++ b/src/Bundle.hx
@@ -69,7 +69,7 @@ class Bundle
 				var pattern = values
 					.map(getString)
 					.map(formatMatch)
-					.join('|');
+					.join(',');
 				var module = '$libName=$pattern';
 				var bridge = '${libName}__BRIDGE__';
 				Split.register(module);

--- a/tool/src/Extractor.hx
+++ b/tool/src/Extractor.hx
@@ -365,7 +365,7 @@ class Extractor
 		var parts = name.split('=');
 		var newName = parts[0];
 		return {
-			test: parts[1].split('|'),
+			test: parts[1].split(','),
 			roots: ({} :DynamicAccess<Bool>),
 			bundle: createBundle(newName, true)
 		};


### PR DESCRIPTION
Delimiter | which was used when macro call external command and pass some data in it, make a problem, 'cause it's special character and interpret as pipe. To avoid it any problems better to replace it for smth general. like ","
