### PR TITLE
Remove unfortunate "tail-call optimisation"

### DIFF
--- a/tool/bin/split.js
+++ b/tool/bin/split.js
@@ -771,7 +771,7 @@ Extractor.prototype = {
 					continue;
 				}
 				parents[node] = lib[0].bundle.name;
-				this.walkGraph(lib[0].bundle,[node],test,parents,children);
+				this.walkGraph(lib[0].bundle,node,test,parents,children);
 			}
 		}
 	}
@@ -786,18 +786,14 @@ Extractor.prototype = {
 			}
 			var mod = this.createBundle($module);
 			parents[$module] = $module;
-			this.walkGraph(mod,[$module],libTest,parents,children);
+			this.walkGraph(mod,$module,libTest,parents,children);
 		}
 		if(children.length > 0) {
 			this.recurseVisit(children,libTest,parents);
 		}
 	}
-	,walkGraph: function(bundle,stack,libTest,parents,children) {
-		if(stack.length == 0) {
-			return;
-		}
+	,walkGraph: function(bundle,target,libTest,parents,children) {
 		var $module = bundle.name;
-		var target = stack.pop();
 		var succ = this.g.successors(target);
 		var _g = 0;
 		while(_g < succ.length) {
@@ -836,9 +832,8 @@ Extractor.prototype = {
 				continue;
 			}
 			parents[node] = $module;
-			stack.push(node);
+			this.walkGraph(bundle,node,libTest,parents,children);
 		}
-		this.walkGraph(bundle,stack,libTest,parents,children);
 	}
 	,shareGraph: function(toBundle,fromBundle,root,parents) {
 		var toModule = toBundle.name;

--- a/tool/src/Extractor.hx
+++ b/tool/src/Extractor.hx
@@ -164,7 +164,7 @@ class Extractor
 				var test = libTest.filter(function(it) return it != lib);
 				if (parents.exists(node)) continue;
 				parents.set(node, lib.bundle.name);
-				walkGraph(lib.bundle, [node], test, parents, children);
+				walkGraph(lib.bundle, node, test, parents, children);
 			}
 		}
 	}
@@ -176,16 +176,14 @@ class Extractor
 			if (module.indexOf('=') > 0 || moduleMap.exists(module) || !g.hasNode(module)) continue;
 			var mod = createBundle(module);
 			parents.set(module, module);
-			walkGraph(mod, [module], libTest, parents, children);
+			walkGraph(mod, module, libTest, parents, children);
 		}
 		if (children.length > 0) recurseVisit(children, libTest, parents);
 	}
 
-	function walkGraph(bundle:Bundle, stack:Array<String>, libTest:Array<LibTest>, parents:DynamicAccess<String>, children:Array<String>)
+	function walkGraph(bundle:Bundle, target:String, libTest:Array<LibTest>, parents:DynamicAccess<String>, children:Array<String>)
 	{
-		if (stack.length == 0) return;
 		var module = bundle.name;
-		var target = stack.pop();
 		var succ = g.successors(target);
 		for (node in succ) {
 			// reached sub modules
@@ -216,9 +214,8 @@ class Extractor
 			}
 			// tag and recurse
 			parents.set(node, module);
-			stack.push(node);
+			walkGraph(bundle, node, libTest, parents, children);
 		}
-		walkGraph(bundle, stack, libTest, parents, children);
 	}
 
 	function shareGraph(toBundle:Bundle, fromBundle:Bundle, root:String, parents:DynamicAccess<String>)


### PR DESCRIPTION
The stack only wastes memory and in practice increases considerably the recursion depth when your VM doesn't have native support for it.