### PR TITLE
Minification flags

### DIFF
--- a/extraParams.hxml
+++ b/extraParams.hxml
@@ -1,5 +1,5 @@
 --macro Split.modules()
--D closure_disabled
+-D closure_slavemode
 -D closure_overwrite
--D uglifyjs_disabled
+-D uglifyjs_slavemode
 -D uglifyjs_overwrite

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "haxe-modular",
-  "version": "0.10.5",
+  "version": "0.10.12",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -107,6 +107,11 @@
         "dreamopt": "0.6.0"
       }
     },
+    "lodash": {
+      "version": "4.17.10",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.10.tgz",
+      "integrity": "sha512-UejweD1pDoXu+AD825lWwp4ZGtSwgnpZxb3JDViD7StjQz+Nb/6l093lx4OQ0foGWNRoc19mWy7BzL+UAK2iVg=="
+    },
     "process-nextick-args": {
       "version": "1.0.7",
       "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-1.0.7.tgz",
@@ -119,17 +124,10 @@
     },
     "react-proxy": {
       "version": "2.0.8",
-      "resolved": "http://registry.npmjs.org/react-proxy/-/react-proxy-2.0.8.tgz",
+      "resolved": "https://registry.npmjs.org/react-proxy/-/react-proxy-2.0.8.tgz",
       "integrity": "sha1-dq54yb5OVNQJz+x7t9UT7H8bKEw=",
       "requires": {
-        "lodash": "4.17.5"
-      },
-      "dependencies": {
-        "lodash": {
-          "version": "4.17.5",
-          "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.5.tgz",
-          "integrity": "sha512-svL3uiZf1RwhH+cWrfZn3A4+U58wbP0tGVTLQPbjplZxZ8ROD9VLuNgsRniTlLe7OlSqR79RUehXgpBW/s0IQw=="
-        }
+        "lodash": "4.17.10"
       }
     },
     "readable-stream": {
@@ -172,7 +170,8 @@
     "uglifyjs": {
       "version": "2.4.11",
       "resolved": "https://registry.npmjs.org/uglifyjs/-/uglifyjs-2.4.11.tgz",
-      "integrity": "sha1-NEDWTgRXWViVJEGOtkHGi7kNET4="
+      "integrity": "sha1-NEDWTgRXWViVJEGOtkHGi7kNET4=",
+      "dev": true
     },
     "util-deprecate": {
       "version": "1.0.2",

--- a/package.json
+++ b/package.json
@@ -23,13 +23,13 @@
     "graphlib": "^2.1.1",
     "react-deep-force-update": "^2.0.1",
     "react-proxy": "^2.0.8",
-    "source-map": "^0.5.6",
+    "source-map": "^0.5.6"
+  },
+  "devDependencies": {
+    "json-diff": "^0.5.2",
     "uglifyjs": "^2.4.11"
   },
   "config": {
     "haxe-split-hook": "tool/test/src/test_hook.js"
-  },
-  "devDependencies": {
-    "json-diff": "^0.5.2"
   }
 }

--- a/src/Split.hx
+++ b/src/Split.hx
@@ -85,8 +85,7 @@ class Split
 	}
 
 	static function compress() {
-		#if !modular_nocompress
-		#if closure
+		#if (closure &&  !closure_disabled)
 		var path = Path.directory(output);
 		var files = [output].concat(bundles.map(function(name) {
 			if (name.indexOf('=') > 0) name = name.split('=')[0];
@@ -98,7 +97,7 @@ class Split
 			closure.Compiler.compileFile(file, file + '.map');
 		}
 		#end
-		#if uglifyjs
+		#if (uglifyjs && !uglifyjs_disabled)
 		var path = Path.directory(output);
 		var files = [output].concat(bundles.map(function(name) {
 			if (name.indexOf('=') > 0) name = name.split('=')[0];
@@ -109,7 +108,6 @@ class Split
 			Sys.println('Compress $file');
 			UglifyJS.compileFile(file, file);
 		}
-		#end
 		#end
 	}
 }


### PR DESCRIPTION
More consistent control of minification libraries with a hidden flag (e.g. `uglifyjs_slavemode`), so the libraries' normal disabling flag (`uglifyjs_disabled`) will work as expected.

Depends on both libraries accepting the flag PR.

+ make NPM uglifyjs dependency a dev-dependency (used only for tests)