### PR TITLE
Use Cherow for parsing instead of Acorn.js

### DIFF
--- a/build.hxml
+++ b/build.hxml
@@ -5,6 +5,7 @@
 
 --next
 
+-D cherow_parser
 -lib hxnodejs
 -cp tool/src
 HxSplit

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "haxe-modular",
-  "version": "0.10.12",
+  "version": "0.10.13",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -16,6 +16,11 @@
       "version": "4.0.13",
       "resolved": "https://registry.npmjs.org/acorn/-/acorn-4.0.13.tgz",
       "integrity": "sha1-EFSVrlNh1pe9GVyCUZLhrX8lN4c="
+    },
+    "cherow": {
+      "version": "1.6.6",
+      "resolved": "https://registry.npmjs.org/cherow/-/cherow-1.6.6.tgz",
+      "integrity": "sha1-3R4M9DeC8CKbPgCrIBvpZxatgcE="
     },
     "cli-color": {
       "version": "0.1.7",

--- a/package.json
+++ b/package.json
@@ -20,6 +20,7 @@
   "dependencies": {
     "@elsassph/fast-source-map": "^0.3.0",
     "acorn": "^4.0.3",
+    "cherow": "^1.6.6",
     "graphlib": "^2.1.1",
     "react-deep-force-update": "^2.0.1",
     "react-proxy": "^2.0.8",

--- a/tool/src/HxSplit.hx
+++ b/tool/src/HxSplit.hx
@@ -12,7 +12,7 @@ class HxSplit
 		astHooks:Array<Graph->String->Array<String>>)
 	{
 		// parse input
-		var src = Fs.readFileSync(input).toString();
+		var src = Fs.readFileSync(input, "utf8");
 		var parser = new Parser(src, debugMode, commonjs);
 		var sourceMap = debugMode ? new SourceMap(input, src) : null;
 

--- a/tool/src/acorn/Cherow.hx
+++ b/tool/src/acorn/Cherow.hx
@@ -1,0 +1,26 @@
+package acorn;
+
+import acorn.Acorn;
+
+typedef CherowOptions = {
+	?module: Bool, // Enable module syntax
+	?loc: Bool, // Attach line/column location information to each node
+	?ranges: Bool, // Append start and end offsets to each node
+	?impliedStrict: Bool, // Enable strict mode initial enforcement
+	?next: Bool, // Enable stage 3 support (ESNext)
+	?tolerant: Bool, // Create a top-level error array containing all "skipped" errors
+	?source: Bool, // Set to true to record the source file in every node's loc object when the loc option is set.
+	?raw: Bool, // Attach raw property to each literal node
+	?rawIdentifier: Bool, // Attach raw property to each identifier node
+}
+
+@:jsRequire('cherow')
+extern class Cherow {
+
+	/**
+	 * is used to parse a JavaScript program. The input parameter is a string, options can
+	 * be undefined or an object setting some of the options listed below. The return value
+	 * will be an abstract syntax tree object as specified by the ESTree spec.
+	 */
+	static public function parse(input:String, options:CherowOptions):AstNode;
+}

--- a/tool/test/test-suite.js
+++ b/tool/test/test-suite.js
@@ -115,14 +115,14 @@ function execTest(className, name, params, isNode, callback) {
 	const folder = `tool/test/bin/${name}`;
 	if (useLib[className]) params += ' -D uselib';
 	var cmd = `haxe tool/test/test-common.hxml -main ${className} -js ${folder}/index.js ${params}`;
-	//console.log(cmd);
+	console.log(cmd);
 	exec(cmd, (err, stdout, stderr) => {
+		console.log(stdout);
 		if (err) {
 			hasFailedCase = 1;
 			console.log(stderr);
 			callback(err);
 		} else {
-			console.log(stdout);
 			runValidation(name, isNode, callback);
 		}
 	});
@@ -132,12 +132,11 @@ function runValidation(name, isNode, callback) {
 	const result = `tool/test/bin/${name}/index.js.json`;
 	const valid = `tool/test/expect/${name}.json`;
 	exec(`node tool/test/validate.js ${result} ${valid}`, (err, stdout, stderr) => {
+		console.log(stdout);
 		if (err) {
 			hasFailedCase = 2;
-			console.log(stdout);
 			callback(err);
 		} else {
-			console.log(stdout);
 			if (isNode) runOutput(name, callback);
 			else callback();
 		}


### PR DESCRIPTION
Implements #26 

Cherow seem to be a good bit faster.

Still using Acorn.js' walker, but there wouldn't be much benefit from using a different implementation. I may later just copy the walker and remove Acorn dependency completely.