### PR TITLE
Haxe 4 preview enum breaking change

### DIFF
--- a/tool/bin/split.js
+++ b/tool/bin/split.js
@@ -1857,7 +1857,7 @@ Bundler.GLOBAL = "typeof window != \"undefined\" ? window : typeof global != \"u
 Bundler.FUNCTION_START = "(function ($hx_exports, $global) { \"use-strict\";\n";
 Bundler.FUNCTION_END = "})(" + "typeof exports != \"undefined\" ? exports : typeof window != \"undefined\" ? window : typeof self != \"undefined\" ? self : this" + ", " + "typeof window != \"undefined\" ? window : typeof global != \"undefined\" ? global : typeof self != \"undefined\" ? self : this" + ");\n";
 Bundler.WP_START = "/* eslint-disable */ \"use strict\"\n";
-Bundler.FRAGMENTS = { MAIN : { EXPORTS : "var $hx_exports = module.exports, $global = global;\n", SHARED : "var $s = $global.$hx_scope = $global.$hx_scope || {};\n"}, CHILD : { EXPORTS : "var $hx_exports = module.exports, $global = global;\n", SHARED : "var $s = $global.$hx_scope;\n"}};
+Bundler.FRAGMENTS = { MAIN : { EXPORTS : "var $hx_exports = module.exports, $global = global;\n", SHARED : "var $s = $global.$hx_scope = $global.$hx_scope || {};\n"}, CHILD : { EXPORTS : "var $hx_exports = module.exports, $global = global;\n", SHARED : "var $s = $global.$hx_scope, $_;\n"}};
 Bundler.generateHtml = global.generateHtml;
 MinifyId.BASE_16 = "abcdefghijklmnop".split("");
 SourceMap.SRC_REF = "//# sourceMappingURL=";

--- a/tool/bin/split.js
+++ b/tool/bin/split.js
@@ -926,7 +926,7 @@ Extractor.prototype = {
 			}
 		}
 		var _g1 = 0;
-		var _g11 = ["$estr","$hxClasses","Std"];
+		var _g11 = ["$estr","$hxClasses","$hxEnums","Std"];
 		while(_g1 < _g11.length) {
 			var enforce = _g11[_g1];
 			++_g1;

--- a/tool/src/Bundler.hx
+++ b/tool/src/Bundler.hx
@@ -44,7 +44,7 @@ class Bundler
 		},
 		CHILD: {
 			EXPORTS: "var $hx_exports = module.exports, $global = global;\n",
-			SHARED: "var $s = $global.$hx_scope;\n"
+			SHARED: "var $s = $global.$hx_scope, $_;\n"
 		}
 	}
 

--- a/tool/src/Extractor.hx
+++ b/tool/src/Extractor.hx
@@ -299,7 +299,7 @@ class Extractor
 				g.setEdge(mainModule, source);
 
 		// force some links to main module
-		for (enforce in ["$estr", "$hxClasses", "Std"]) {
+		for (enforce in ["$estr", "$hxClasses", "$hxEnums", "Std"]) {
 			if (!g.hasNode(enforce)) continue;
 			if (!g.hasEdge(mainModule, enforce))
 				g.setEdge(mainModule, enforce);


### PR DESCRIPTION
New compact Haxe 4 enums declaration uses `$_` which is declared once and not shared. 
A new shared object is also introduced: `$hxEnums` which keeps references to declared Enums, like `$hxClasses` does.

Fix: declare `$_` in every child module in case an enum is declared.