### PR TITLE
Fix shareGraph infinite loop

### DIFF
--- a/tool/bin/split.js
+++ b/tool/bin/split.js
@@ -827,7 +827,9 @@ Extractor.prototype = {
 				if(!owner.isMain) {
 					var parentModule = this.commonParent(bundle,owner);
 					var parent = this.moduleMap[parentModule];
-					this.shareGraph(parent,owner,node,parents);
+					if(parent != owner) {
+						this.shareGraph(parent,owner,node,parents);
+					}
 				}
 				continue;
 			}

--- a/tool/src/Extractor.hx
+++ b/tool/src/Extractor.hx
@@ -208,7 +208,7 @@ class Extractor
 				if (!owner.isMain) {
 					var parentModule = commonParent(bundle, owner);
 					var parent = moduleMap.get(parentModule);
-					shareGraph(parent, owner, node, parents);
+					if (parent != owner) shareGraph(parent, owner, node, parents);
 				}
 				continue;
 			}


### PR DESCRIPTION
In some cases, resolving a common parent of shared nodes can lead to infinite loop.