### PR TITLE
Expose sync/async option when loading bundle

### DIFF
--- a/src/Bundle.hx
+++ b/src/Bundle.hx
@@ -12,7 +12,7 @@ class Bundle
 	 * Load async application bundle created with `classRef` as entry point
 	 * Note: excution is synchronous in nodejs; the Promise can be ignored
 	 */
-	macro static public function load(classRef:Expr)
+	macro static public function load(classRef:Expr, sync:Bool = #if nodejs true #else false #end)
 	{
 		switch (Context.typeof(classRef))
 		{
@@ -25,25 +25,26 @@ class Bundle
 				#else
 
 				var bridge = macro var _ = untyped $i{module} = $p{["$s", module]};
-				#if nodejs
-				var jsModule = './$module';
-				return macro cast {
-					untyped require($v{jsModule});
-					$bridge;
-					js.Promise.resolve($v{module});
+				
+				if(sync) {
+					var jsModule = './$module';
+					return macro cast {
+						untyped require($v{jsModule});
+						$bridge;
+						js.Promise.resolve($v{module});
+					}
+				} else {
+					return macro {
+						#if debug
+						Require.hot(function(_) $bridge, $v{module});
+						#end
+						@:keep Require.module($v{module})
+							.then(function(id:String) {
+								$bridge;
+								return id;
+							});
+					}
 				}
-				#else
-				return macro {
-					#if debug
-					Require.hot(function(_) $bridge, $v{module});
-					#end
-					@:keep Require.module($v{module})
-						.then(function(id:String) {
-							$bridge;
-							return id;
-						});
-				}
-				#end
 				#end
 			default:
 				Context.fatalError('Module bundling needs to be provided a module class reference', Context.currentPos());


### PR DESCRIPTION
This is mainly for electron. Because I would have to add `-lib hxnodejs` to enable some nodejs API while I still want to load bundles from remote asynchronously.