### PR TITLE
Support Haxe ES6 output

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 language: haxe
 
 haxe:
-  - 3.4.4
+  - 3.4.7
   - stable
   - development
 
@@ -20,8 +20,9 @@ before_script:
   - haxe build-tool.hxml
 
 script:
-  - node tool/test/test-suite.js
-  - node tool/test/test-suite.js es6
+  if: group = stable
+    - node tool/test/test-suite.js
+    - node tool/test/test-suite.js es6
 
 deploy:
   - provider: script

--- a/.travis.yml
+++ b/.travis.yml
@@ -20,9 +20,8 @@ before_script:
   # - haxe build-tool.hxml
 
 script:
-  if: group = stable
-    - node tool/test/test-suite.js
-    - node tool/test/test-suite.js es6
+  - node tool/test/test-suite.js
+  - node tool/test/test-suite.js es6
 
 deploy:
   - provider: script

--- a/.travis.yml
+++ b/.travis.yml
@@ -21,6 +21,7 @@ before_script:
 
 script:
   - node tool/test/test-suite.js
+  - node tool/test/test-suite.js es6
 
 deploy:
   - provider: script

--- a/.travis.yml
+++ b/.travis.yml
@@ -16,8 +16,8 @@ install:
   - haxelib install uglifyjs
 
 before_script:
-  - haxe build-viewer.hxml
-  - haxe build-tool.hxml
+  # - haxe build-viewer.hxml
+  # - haxe build-tool.hxml
 
 script:
   if: group = stable

--- a/package-lock.json
+++ b/package-lock.json
@@ -13,9 +13,14 @@
       }
     },
     "acorn": {
-      "version": "4.0.13",
-      "resolved": "https://registry.npmjs.org/acorn/-/acorn-4.0.13.tgz",
-      "integrity": "sha1-EFSVrlNh1pe9GVyCUZLhrX8lN4c="
+      "version": "7.1.0",
+      "resolved": "https://registry.npmjs.org/acorn/-/acorn-7.1.0.tgz",
+      "integrity": "sha512-kL5CuoXA/dgxlBbVrflsflzQ3PAas7RYZB52NOm/6839iVYJgKMJ3cQJD+t2i5+qFa8h3MDpEOJiS64E8JLnSQ=="
+    },
+    "acorn-walk": {
+      "version": "7.1.1",
+      "resolved": "https://registry.npmjs.org/acorn-walk/-/acorn-walk-7.1.1.tgz",
+      "integrity": "sha512-wdlPY2tm/9XBr7QkKlq0WQVgiuGTX6YWPyRyBviSoScBuLfTVQhvwg6wJ369GJ/1nPfTLMfnrFIfjqVg6d+jQQ=="
     },
     "align-text": {
       "version": "0.1.4",
@@ -43,6 +48,11 @@
         "align-text": "^0.1.3",
         "lazy-cache": "^1.0.3"
       }
+    },
+    "cherow": {
+      "version": "1.6.9",
+      "resolved": "https://registry.npmjs.org/cherow/-/cherow-1.6.9.tgz",
+      "integrity": "sha512-pmmkpIQRcnDA7EawKcg9+ncSZNTYfXqDx+K3oqqYvpZlqVBChjTomTfw+hePnkqYR3Y013818c0R1Q5P/7PGrQ=="
     },
     "cli-color": {
       "version": "0.1.7",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "haxe-modular",
-  "version": "0.11.2",
+  "version": "0.11.3",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -49,11 +49,6 @@
         "lazy-cache": "^1.0.3"
       }
     },
-    "cherow": {
-      "version": "1.6.9",
-      "resolved": "https://registry.npmjs.org/cherow/-/cherow-1.6.9.tgz",
-      "integrity": "sha512-pmmkpIQRcnDA7EawKcg9+ncSZNTYfXqDx+K3oqqYvpZlqVBChjTomTfw+hePnkqYR3Y013818c0R1Q5P/7PGrQ=="
-    },
     "cli-color": {
       "version": "0.1.7",
       "resolved": "https://registry.npmjs.org/cli-color/-/cli-color-0.1.7.tgz",
@@ -128,18 +123,11 @@
       "dev": true
     },
     "graphlib": {
-      "version": "2.1.5",
-      "resolved": "https://registry.npmjs.org/graphlib/-/graphlib-2.1.5.tgz",
-      "integrity": "sha512-XvtbqCcw+EM5SqQrIetIKKD+uZVNQtDPD1goIg7K73RuRZtVI5rYMdcCVSHm/AS1sCBZ7vt0p5WgXouucHQaOA==",
+      "version": "2.1.8",
+      "resolved": "https://registry.npmjs.org/graphlib/-/graphlib-2.1.8.tgz",
+      "integrity": "sha512-jcLLfkpoVGmH7/InMC/1hIvOPSUh38oJtGhvrOFGzioE1DZ+0YW16RgmOJhHiuWTvGiJQ9Z1Ik43JvkRPRvE+A==",
       "requires": {
-        "lodash": "^4.11.1"
-      },
-      "dependencies": {
-        "lodash": {
-          "version": "4.17.5",
-          "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.5.tgz",
-          "integrity": "sha512-svL3uiZf1RwhH+cWrfZn3A4+U58wbP0tGVTLQPbjplZxZ8ROD9VLuNgsRniTlLe7OlSqR79RUehXgpBW/s0IQw=="
-        }
+        "lodash": "^4.17.15"
       }
     },
     "heap": {

--- a/package.json
+++ b/package.json
@@ -21,8 +21,7 @@
     "@elsassph/fast-source-map": "^0.3.0",
     "acorn": "^7.1.0",
     "acorn-walk": "^7.1.1",
-    "cherow": "^1.6.9",
-    "graphlib": "^2.1.1",
+    "graphlib": "^2.1.8",
     "react-deep-force-update": "^2.0.1",
     "react-proxy": "^2.0.8",
     "source-map": "^0.5.6"

--- a/package.json
+++ b/package.json
@@ -19,7 +19,9 @@
   "license": "ISC",
   "dependencies": {
     "@elsassph/fast-source-map": "^0.3.0",
-    "acorn": "^4.0.3",
+    "acorn": "^7.1.0",
+    "acorn-walk": "^7.1.1",
+    "cherow": "^1.6.9",
     "graphlib": "^2.1.1",
     "react-deep-force-update": "^2.0.1",
     "react-proxy": "^2.0.8",

--- a/tool/bin/split.js
+++ b/tool/bin/split.js
@@ -1234,7 +1234,7 @@ class MinifyId {
 MinifyId.__name__ = true;
 class Parser {
 	constructor(src,withLocation,commonjs) {
-		this.objectMethods = { "defineProperty" : true, "defineProperties" : true, "freeze" : true};
+		this.objectMethods = { "defineProperty" : true, "defineProperties" : true, "freeze" : true, "assign" : true};
 		this.reservedTypes = { "String" : true, "Math" : true, "Array" : true, "Date" : true, "Number" : true, "Boolean" : true, __map_reserved : true};
 		this.mainModule = "Main";
 		var t0 = new Date().getTime();
@@ -1246,7 +1246,7 @@ class Parser {
 		haxe_Log.trace("AST processed in: " + (t2 - t1) + "ms",{ fileName : "tool/src/Parser.hx", lineNumber : 35, className : "Parser", methodName : "new"});
 	}
 	processInput(src,withLocation) {
-		var options = { ecmaVersion : 5, allowReserved : true};
+		var options = { ecmaVersion : 6, allowReserved : true};
 		if(withLocation) {
 			options.locations = true;
 		}
@@ -1337,6 +1337,9 @@ class Parser {
 			var node = body[_g];
 			++_g;
 			switch(node.type) {
+			case "ClassDeclaration":
+				this.inspectClass(node.id,node);
+				break;
 			case "EmptyStatement":
 				break;
 			case "ExpressionStatement":
@@ -1356,7 +1359,7 @@ class Parser {
 				this.inspectDeclarations(node.declarations,node);
 				break;
 			default:
-				haxe_Log.trace("WARNING: Unexpected " + node.type + ", at character " + node.start,{ fileName : "tool/src/Parser.hx", lineNumber : 158, className : "Parser", methodName : "walkDeclarations"});
+				haxe_Log.trace("WARNING: Unexpected " + node.type + ", at character " + node.start,{ fileName : "tool/src/Parser.hx", lineNumber : 160, className : "Parser", methodName : "walkDeclarations"});
 			}
 		}
 	}
@@ -1375,6 +1378,13 @@ class Parser {
 			if(name == "$extend" || name == "$bind" || name == "$iterator") {
 				this.tag(name,def);
 			}
+		}
+	}
+	inspectClass(id,def) {
+		var path = this.getIdentifier(id);
+		if(path.length > 0) {
+			var name = path[0];
+			this.tag(name,def);
 		}
 	}
 	inspectExpression(expression,def) {

--- a/tool/bin/split.js
+++ b/tool/bin/split.js
@@ -1394,13 +1394,11 @@ class Parser {
 			if(path.length > 0) {
 				var name = path[0];
 				switch(name) {
-				case "$hxClasses":
+				case "$hxClasses":case "$hx_exports":
 					var moduleName = this.getIdentifier(expression.right);
 					if(moduleName.length == 1) {
 						this.tag(moduleName[0],def);
 					}
-					break;
-				case "$hx_exports":
 					break;
 				default:
 					if(Object.prototype.hasOwnProperty.call(this.types,name)) {
@@ -1560,6 +1558,8 @@ class Parser {
 			return [];
 		}
 		switch(left.type) {
+		case "AssignmentExpression":
+			return this.getIdentifier(left.right);
 		case "Identifier":
 			return [left.name];
 		case "Literal":

--- a/tool/bin/split.js
+++ b/tool/bin/split.js
@@ -372,7 +372,6 @@ class Bundler {
 			haxe_Log.trace("Emit " + bundleOutput,{ fileName : "tool/src/Bundler.hx", lineNumber : 95, className : "Bundler", methodName : "generate"});
 			var buffer = this.emitBundle(src,bundle,isMain);
 			results[i1] = { name : bundle.name, map : this.writeMap(bundleOutput,buffer), source : this.write(bundleOutput,buffer.src), debugMap : buffer.debugMap};
-			isMain = false;
 		}
 		return results;
 	}
@@ -489,20 +488,20 @@ class Bundler {
 		try {
 			return Bundler.generateHtml(consumer,src,sourcesContent);
 		} catch( err ) {
-			haxe_Log.trace("[WARNING] error while generating debug map for " + bundle.name + ": " + Std.string(((err) instanceof js__$Boot_HaxeError) ? err.val : err),{ fileName : "tool/src/Bundler.hx", lineNumber : 231, className : "Bundler", methodName : "emitDebugMap"});
+			haxe_Log.trace("[WARNING] error while generating debug map for " + bundle.name + ": " + Std.string(((err) instanceof js__$Boot_HaxeError) ? err.val : err),{ fileName : "tool/src/Bundler.hx", lineNumber : 230, className : "Bundler", methodName : "emitDebugMap"});
 			return null;
 		}
 	}
 	emitJS(src,bundle,isMain) {
 		var _gthis = this;
 		this.reporter.start(bundle);
-		var mapOffset = 0;
 		var imports = Reflect.fields(bundle.imports);
 		var shared = Reflect.fields(bundle.shared);
 		var exports = Reflect.fields(bundle.exports);
-		var buffer = "";
 		var body = this.parser.rootBody;
 		var hasSourceMap = this.sourceMap != null;
+		var mapOffset = 0;
+		var buffer = "";
 		if(isMain) {
 			buffer += this.getBeforeBodySrc(src);
 			if(hasSourceMap) {
@@ -1306,8 +1305,7 @@ class Parser {
 		this.types = { };
 		this.isEnum = { };
 		this.isRequire = { };
-		var body = this.getBodyNodes(program);
-		this.rootExpr = body.pop();
+		this.rootExpr = this.getBodyNodes(program).pop();
 		if(this.rootExpr.type == "ExpressionStatement") {
 			this.walkRootExpression(this.rootExpr.expression);
 		} else {
@@ -1359,7 +1357,7 @@ class Parser {
 				this.inspectDeclarations(node.declarations,node);
 				break;
 			default:
-				haxe_Log.trace("WARNING: Unexpected " + node.type + ", at character " + node.start,{ fileName : "tool/src/Parser.hx", lineNumber : 160, className : "Parser", methodName : "walkDeclarations"});
+				haxe_Log.trace("WARNING: Unexpected " + node.type + ", at character " + node.start,{ fileName : "tool/src/Parser.hx", lineNumber : 159, className : "Parser", methodName : "walkDeclarations"});
 			}
 		}
 	}
@@ -1424,11 +1422,11 @@ class Parser {
 					}
 					this.tag(name1,def);
 				} else if(name1 == "Object" && this.objectMethods[member] && expression.arguments != null && expression.arguments[0] != null) {
-					path1 = this.getIdentifier(expression.arguments[0].object);
-					if(path1.length == 1) {
-						name1 = path1[0];
-						if(Object.prototype.hasOwnProperty.call(this.types,name1)) {
-							this.tag(name1,def);
+					var spath = this.getIdentifier(expression.arguments[0].object);
+					if(spath.length == 1) {
+						var sname = spath[0];
+						if(Object.prototype.hasOwnProperty.call(this.types,sname)) {
+							this.tag(sname,def);
 						}
 					}
 				}
@@ -1706,8 +1704,8 @@ class SourceMap {
 		if(p < 0) {
 			return;
 		}
-		this.fileName = StringTools.trim(HxOverrides.substr(src,p + "//# sourceMappingURL=".length,null));
-		this.fileName = js_node_Path.join(js_node_Path.dirname(input),this.fileName);
+		var srcName = StringTools.trim(HxOverrides.substr(src,p + "//# sourceMappingURL=".length,null));
+		this.fileName = js_node_Path.join(js_node_Path.dirname(input),srcName);
 		this.source = SM.decodeFile(this.fileName);
 	}
 	emitMappings(nodes,offset) {

--- a/tool/bin/viewer.js
+++ b/tool/bin/viewer.js
@@ -292,6 +292,7 @@ class StatsViewer {
 			_gthis.delayResize = haxe_Timer.delay(function() {
 				_gthis.delayResize = null;
 				_gthis.foamtree.resize();
+				return;
 			},300);
 		});
 		window.addEventListener("mousemove",function(e) {
@@ -366,10 +367,12 @@ class StatsViewer {
 					_gthis.foamtree.set("dataObject",{ groups : groups});
 					window.history.pushState(null,_gthis.pendingGroup.label);
 					_gthis.clearTip();
+					return;
 				},100);
 			} else {
 				_gthis.foamtree.zoom(_gthis.pendingGroup);
 			}
+			return;
 		},300);
 	}
 	setDepth(groups) {

--- a/tool/src/Bundler.hx
+++ b/tool/src/Bundler.hx
@@ -48,13 +48,13 @@ class Bundler
 		}
 	}
 
-	static var generateHtml:SourceMapConsumer->String->Array<String>->String = untyped global.generateHtml;
+	static final generateHtml:SourceMapConsumer->String->Array<String>->String = untyped global.generateHtml;
 
-	var parser:Parser;
-	var sourceMap:SourceMap;
-	var extractor:Extractor;
-	var reporter:Reporter;
-	var minifyId:MinifyId;
+	final parser:Parser;
+	final sourceMap:SourceMap;
+	final extractor:Extractor;
+	final reporter:Reporter;
+	final minifyId:MinifyId;
 	var commonjs:Bool;
 	var debugSourceMap:Bool;
 	var nodejsMode:Bool;
@@ -80,28 +80,27 @@ class Bundler
 
 		// lookup-map between identifiers and bundles
 		revMap = {};
-		var len = bundles.length;
+		final len = bundles.length;
 		for (i in 0...len) createRevMap(i, bundles[i]);
 
 		// filter output nodes for each bundle
 		buildIndex(src);
 
 		// emit
-		var results = [];
+		final results = [];
 		for (i in 0...len) {
-			var bundle = bundles[i];
-			var isMain = bundle.isMain;
-			var bundleOutput = isMain ? output : Path.join(Path.dirname(output), bundle.name + '.js');
+			final bundle = bundles[i];
+			final isMain = bundle.isMain;
+			final bundleOutput = isMain ? output : Path.join(Path.dirname(output), bundle.name + '.js');
 			trace('Emit $bundleOutput');
 
-			var buffer = emitBundle(src, bundle, isMain);
+			final buffer = emitBundle(src, bundle, isMain);
 			results[i] = {
 				name: bundle.name,
 				map: writeMap(bundleOutput, buffer),
 				source: write(bundleOutput, buffer.src),
 				debugMap: buffer.debugMap
 			};
-			isMain = false;
 		}
 		return results;
 	}
@@ -111,15 +110,15 @@ class Bundler
 		#if verbose_debug
 		trace('Build index...');
 		#end
-		var ids = idMap = {};
+		final ids = idMap = {};
 		if (!commonjs) ids.set('require', true);
-		var rev = revMap;
-		var body = parser.rootBody;
-		var bodyLength = body.length;
-		var bundlesLength = bundles.length;
+		final rev = revMap;
+		final body = parser.rootBody;
+		final bodyLength = body.length;
+		final bundlesLength = bundles.length;
 		for (i in 1...bodyLength)
 		{
-			var node = body[i];
+			final node = body[i];
 			// Non-attributed nodes go in all bundles
 			if (node.__tag__ == null) {
 				#if verbose_debug
@@ -144,7 +143,7 @@ class Bundler
 				#end
 
 				for (j in 0...list.length) {
-					var index = list[j];
+					final index = list[j];
 					if (index == 0) node.__main__ = true;
 					else bundles[index].indexes.push(i);
 				}
@@ -170,11 +169,11 @@ class Bundler
 	function createRevMap(index:Int, bundle:Bundle)
 	{
 		minifyId.set(bundle.name);
-		var rev = revMap;
-		var nodes = bundle.nodes;
-		var len = nodes.length;
+		final rev = revMap;
+		final nodes = bundle.nodes;
+		final len = nodes.length;
 		for (i in 0...len) {
-			var list = rev.get(nodes[i]);
+			final list = rev.get(nodes[i]);
 			if (list != null) list.push(index);
 			else rev.set(nodes[i], [index]);
 		}
@@ -200,9 +199,9 @@ class Bundler
 
 	function emitBundle(src:String, bundle:Bundle, isMain:Bool):OutputBuffer
 	{
-		var output = emitJS(src, bundle, isMain);
-		var map = sourceMap != null ? sourceMap.emitMappings(output.mapNodes, output.mapOffset) : null;
-		var debugMap = debugSourceMap && map != null ? emitDebugMap(output.buffer, bundle, map) : null;
+		final output = emitJS(src, bundle, isMain);
+		final map = sourceMap != null ? sourceMap.emitMappings(output.mapNodes, output.mapOffset) : null;
+		final debugMap = debugSourceMap && map != null ? emitDebugMap(output.buffer, bundle, map) : null;
 		return {
 			src:output.buffer,
 			map:map,
@@ -214,13 +213,13 @@ class Bundler
 	{
 		if (rawMap.sources.length == 0) return null;
 		// library doesn't like empty strings
-		rawMap.sources = rawMap.sources.map(function(url) return url == '' ? null : url);
+		rawMap.sources = rawMap.sources.map(url -> url == '' ? null : url);
 
-		var consumer = new SourceMapConsumer(rawMap);
-		var sourcesContent = [for (source in rawMap.sources) {
+		final consumer = new SourceMapConsumer(rawMap);
+		final sourcesContent = [for (source in rawMap.sources) {
 			if (source == null || source == '') '';
 			else {
-				var fileName = source.split('file://').pop();
+				final fileName = source.split('file://').pop();
 				Fs.readFileSync(fileName).toString();
 			}
 		}];
@@ -237,13 +236,13 @@ class Bundler
 	{
 		reporter.start(bundle);
 
+		final imports = bundle.imports.keys();
+		final shared = bundle.shared.keys();
+		final exports = bundle.exports.keys();
+		final body = parser.rootBody;
+		final hasSourceMap = sourceMap != null;
 		var mapOffset = 0;
-		var imports = bundle.imports.keys();
-		var shared = bundle.shared.keys();
-		var exports = bundle.exports.keys();
 		var buffer = '';
-		var body = parser.rootBody;
-		var hasSourceMap = sourceMap != null;
 
 		// include code before HaxeJS output only in main JS
 		if (isMain) {
@@ -252,10 +251,10 @@ class Bundler
 		}
 		else mapOffset++;
 
-		var inc = bundle.nodes;
-		var incAll = isMain && bundle.nodes.length == 0;
-		var mapNodes:Array<AstNode> = [];
-		var frag = isMain || bundle.isLib ? FRAGMENTS.MAIN : FRAGMENTS.CHILD;
+		final inc = bundle.nodes;
+		final incAll = isMain && bundle.nodes.length == 0;
+		final mapNodes:Array<AstNode> = [];
+		final frag = isMain || bundle.isLib ? FRAGMENTS.MAIN : FRAGMENTS.CHILD;
 
 		// header
 		if (commonjs)
@@ -283,7 +282,7 @@ class Bundler
 		}
 		if (imports.length > 0 || shared.length > 0)
 		{
-			var tmp = shared.concat([for (node in imports) '$node = $$s.${minifyId.get(node)}']);
+			final tmp = shared.concat([for (node in imports) '$node = $$s.${minifyId.get(node)}']);
 			buffer += 'var ${tmp.join(', ')};\n';
 			mapOffset++;
 		}
@@ -291,14 +290,14 @@ class Bundler
 		// split main content
 		if (isMain)
 		{
-			var len = body.length - 1;
+			final len = body.length - 1;
 			for (i in 1...len)
 			{
-				var node = body[i];
+				final node = body[i];
 				if (!incAll && !node.__main__)
 					continue;
 				if (hasSourceMap) mapNodes.push(node);
-				var chunk = src.substr(node.start, node.end - node.start);
+				final chunk = src.substr(node.start, node.end - node.start);
 				reporter.add(node.__tag__, chunk.length);
 				buffer += chunk;
 				buffer += '\n';
@@ -306,13 +305,13 @@ class Bundler
 		}
 		else
 		{
-			var indexes = bundle.indexes;
-			var len = indexes.length;
+			final indexes = bundle.indexes;
+			final len = indexes.length;
 			for (i in 0...len)
 			{
-				var node = body[indexes[i]];
+				final node = body[indexes[i]];
 				if (hasSourceMap) mapNodes.push(node);
-				var chunk = src.substr(node.start, node.end - node.start);
+				final chunk = src.substr(node.start, node.end - node.start);
 				reporter.add(node.__tag__, chunk.length);
 				buffer += chunk;
 				buffer += '\n';
@@ -334,17 +333,17 @@ class Bundler
 		if (isMain)
 		{
 			// entry point
-			var run = body[body.length - 1];
+			final run = body[body.length - 1];
 			buffer += src.substr(run.start, run.end - run.start);
 			buffer += '\n';
 
 			// main libs bridge
 			for (bundle in extractor.bundles) {
 				if (!bundle.isLib) continue;
-				var match = '"${bundle.name}__BRIDGE__"';
+				final match = '"${bundle.name}__BRIDGE__"';
 				var bridge = bundle.exports.keys()
-					.filter(function(node) return shared.indexOf(node) >= 0)
-					.map(function(node) return '$node = $$s.${minifyId.get(node)}')
+					.filter(node -> shared.indexOf(node) >= 0)
+					.map(node -> '$node = $$s.${minifyId.get(node)}')
 					.join(', ');
 				if (bridge == '') bridge = '0';
 				buffer = buffer.split(match).join('($bridge)');
@@ -367,14 +366,14 @@ class Bundler
 
 	function getBeforeBodySrc(src:String)
 	{
-		var chunk = src.substr(0, parser.rootExpr.start);
+		final chunk = src.substr(0, parser.rootExpr.start);
 		reporter.includedBefore(chunk.length);
 		return chunk;
 	}
 
 	function emitHot(inc:Array<String>)
 	{
-		var names = [];
+		final names = [];
 		for (name in parser.isHot.keys())
 			if (parser.isHot.get(name) && inc.indexOf(name) >= 0) names.push(name);
 

--- a/tool/src/Bundler.hx
+++ b/tool/src/Bundler.hx
@@ -1,4 +1,4 @@
-import acorn.Acorn.AstNode;
+import ast.AstNode;
 import haxe.DynamicAccess;
 import js.node.Fs;
 import js.node.Path;
@@ -220,7 +220,7 @@ class Bundler
 			if (source == null || source == '') '';
 			else {
 				final fileName = source.split('file://').pop();
-				Fs.readFileSync(fileName).toString();
+				Fs.readFileSync(fileName, 'utf8');
 			}
 		}];
 		try {

--- a/tool/src/Extractor.hx
+++ b/tool/src/Extractor.hx
@@ -22,7 +22,7 @@ class Extractor
 	public var bundles(default, null):Array<Bundle>;
 	public var mainLibs:Map<String, Array<String>>;
 
-	var parser:Parser;
+	final parser:Parser;
 	var g:Graph;
 	var hmrMode:Bool;
 	var mainModule:String;
@@ -44,7 +44,7 @@ class Extractor
 
 	public function process(mainModule:String, modulesList:Array<String>, debugMode:Bool)
 	{
-		var t0 = Date.now().getTime();
+		final t0 = Date.now().getTime();
 		trace('Bundling...');
 		moduleMap = {};
 		parenting = new Graph();
@@ -71,10 +71,10 @@ class Extractor
 		if (debugMode) linkEnums(mainModule, parser.isEnum.keys());
 
 		// find libs
-		var libTest:Array<LibTest> = expandLibs();
+		final libTest:Array<LibTest> = expandLibs();
 
 		// process graph
-		var parents = {};
+		final parents = {};
 		recurseVisit([mainModule], libTest, parents);
 		recurseVisit(modules, libTest, parents); // modules can be isolated from entry point
 		walkLibs(libTest, parents);
@@ -82,12 +82,12 @@ class Extractor
 
 		// format results
 		main = moduleMap.get(mainModule);
-		bundles = modules.map(function(module) {
-			var name = module.indexOf('=') > 0 ? module.split('=')[0] : module;
+		bundles = modules.map(module -> {
+			final name = module.indexOf('=') > 0 ? module.split('=')[0] : module;
 			return moduleMap.get(name);
-		}).filter(function(bundle) return bundle != null);
+		}).filter(bundle -> bundle != null);
 
-		var t1 = Date.now().getTime();
+		final t1 = Date.now().getTime();
 		trace('Graph processed in: ${t1 - t0}ms');
 		#if debug
 		trace(main);
@@ -99,19 +99,19 @@ class Extractor
 	{
 		// Now that nodes having attributed to bundles,
 		// re-walk the graph to populate bundles' nodes/exports/imports/shared
-		var bundle = moduleMap.get(mainModule);
+		final bundle = moduleMap.get(mainModule);
 		recursePopulate(bundle, mainModule, parents, {});
 	}
 
 	function recursePopulate(bundle:Bundle, root:String, parents:DynamicAccess<String>, visited:DynamicAccess<Bool>)
 	{
 		bundle.nodes.push(root);
-		var module = bundle.name;
-		var succ = g.successors(root);
+		final module = bundle.name;
+		final succ = g.successors(root);
 		var parent:Bundle;
 		for (node in succ) {
 			// find node owner
-			var parentModule = parents.get(node);
+			final parentModule = parents.get(node);
 			if (parentModule == module) {
 				// same bundle
 				parent = bundle;
@@ -143,10 +143,10 @@ class Extractor
 	function walkLibs(libTest:Array<LibTest>, parents:DynamicAccess<String>)
 	{
 		// libs don't have a single root, any number of disconnected classes can be referenced
-		var children = [];
+		final children = [];
 		for (lib in libTest) {
 			for (node in lib.roots.keys()) {
-				var test = libTest.filter(function(it) return it != lib);
+				final test = libTest.filter(it -> it != lib);
 				if (parents.exists(node)) continue;
 				parents.set(node, lib.bundle.name);
 				walkGraph(lib.bundle, node, test, parents, children);
@@ -156,10 +156,10 @@ class Extractor
 
 	function recurseVisit(modules:Array<String>, libTest:Array<LibTest>, parents:DynamicAccess<String>)
 	{
-		var children = [];
+		final children = [];
 		for (module in modules) {
 			if (module.indexOf('=') > 0 || moduleMap.exists(module) || !g.hasNode(module)) continue;
-			var mod = createBundle(module);
+			final mod = createBundle(module);
 			parents.set(module, module);
 			walkGraph(mod, module, libTest, parents, children);
 		}
@@ -168,12 +168,12 @@ class Extractor
 
 	function walkGraph(bundle:Bundle, target:String, libTest:Array<LibTest>, parents:DynamicAccess<String>, children:Array<String>)
 	{
-		var module = bundle.name;
-		var succ = g.successors(target);
+		final module = bundle.name;
+		final succ = g.successors(target);
 		for (node in succ) {
 			// reached sub modules
 			if (moduleTest.exists(node)) {
-				var childModule = node;
+				final childModule = node;
 				// create only edge from parent to child
 				if (!parenting.hasEdge(childModule, module)) {
 					parenting.setEdge(module, childModule);
@@ -187,12 +187,12 @@ class Extractor
 			}
 			// deduplicate
 			if (parents.exists(node)) {
-				var ownerModule = parents.get(node);
+				final ownerModule = parents.get(node);
 				if (ownerModule == module) continue;
-				var owner = moduleMap.get(ownerModule);
+				final owner = moduleMap.get(ownerModule);
 				if (!owner.isMain) {
-					var parentModule = commonParent(bundle, owner);
-					var parent = moduleMap.get(parentModule);
+					final parentModule = commonParent(bundle, owner);
+					final parent = moduleMap.get(parentModule);
 					if (parent != owner) shareGraph(parent, owner, node, parents);
 				}
 				continue;
@@ -207,12 +207,12 @@ class Extractor
 	{
 		// A node was found to be referenced by 2 bundles:
 		// it should be hoisted in the parent bundle, along with its children
-		var toModule = toBundle.name;
-		var fromModule = fromBundle.name;
+		final toModule = toBundle.name;
+		final fromModule = fromBundle.name;
 		parents.set(root, toModule);
-		var succ = g.successors(root);
+		final succ = g.successors(root);
 		for (node in succ) {
-			var current = parents.get(node);
+			final current = parents.get(node);
 			if (current == fromModule) {
 				shareGraph(toBundle, fromBundle, node, parents);
 			}
@@ -221,8 +221,8 @@ class Extractor
 
 	function commonParent(b1:Bundle, b2:Bundle)
 	{
-		var p1 = parentsOf(b1.name, {});
-		var p2 = parentsOf(b2.name, {});
+		final p1 = parentsOf(b1.name, {});
+		final p2 = parentsOf(b2.name, {});
 		var i1 = p1.length - 1;
 		var i2 = p2.length - 1;
 		var parent = mainModule;
@@ -236,7 +236,7 @@ class Extractor
 
 	function parentsOf(module:String, visited:DynamicAccess<Bool>)
 	{
-		var pred = parenting.predecessors(module);
+		final pred = parenting.predecessors(module);
 		var best:Array<String> = null;
 		for (p in pred) {
 			if (visited.exists(p)) continue;
@@ -252,7 +252,7 @@ class Extractor
 
 	inline function isInLib(node:String, libTest:Array<LibTest>)
 	{
-		var lib = libMap.get(node);
+		final lib = libMap.get(node);
 		if (lib != null && libTest.indexOf(lib) >= 0) {
 			lib.roots.set(node, true);
 			return true;
@@ -264,15 +264,15 @@ class Extractor
 	{
 		// deduplicate and merge modules
 		modules = [];
-		var modulesMap:DynamicAccess<Array<String>> = {};
+		final modulesMap:DynamicAccess<Array<String>> = {};
 		for (module in modulesList) {
 			if (module.indexOf('=') > 0) {
-				var parts = module.split('=');
-				var name = parts[0];
+				final parts = module.split('=');
+				final name = parts[0];
 				if (!modulesMap.exists(name)) modulesMap.set(name, []);
 				for (m in parts[1].split(","))
 					if (modulesMap.get(name).indexOf(m) < 0) modulesMap.get(name).push(m);
-			} 
+			}
 			else if (modules.indexOf(module) < 0) modules.push(module);
 		}
 		modules = modules.concat([for (name in modulesMap.keys()) '$name=${modulesMap.get(name).join(",")}']);
@@ -288,7 +288,7 @@ class Extractor
 	function linkOrphans()
 	{
 		// link "orphan" classes to main module
-		var sources = g.sources();
+		final sources = g.sources();
 		for (source in sources)
 			if (source != mainModule)
 				g.setEdge(mainModule, source);
@@ -303,7 +303,7 @@ class Extractor
 
 	function createBundle(name:String, isLib:Bool = false)
 	{
-		var bundle:Bundle = {
+		final bundle:Bundle = {
 			isMain: name == mainModule,
 			isLib: isLib,
 			name: name,
@@ -321,12 +321,12 @@ class Extractor
 	function expandLibs()
 	{
 		libMap = {};
-		var libTest:Array<LibTest> = [];
-		var allNodes = parser.graph.nodes();
+		final libTest:Array<LibTest> = [];
+		final allNodes = parser.graph.nodes();
 		for (i in 0...modules.length) {
-			var module = modules[i];
+			final module = modules[i];
 			if (module.indexOf('=') > 0) {
-				var lib = resolveLib(module);
+				final lib = resolveLib(module);
 				mapLibTypes(allNodes, lib);
 				libTest.push(lib);
 			}
@@ -337,10 +337,10 @@ class Extractor
 	function mapLibTypes(allNodes:Array<String>, lib:LibTest)
 	{
 		// match each node with owning lib
-		var test = lib.test;
-		var n = test.length;
+		final test = lib.test;
+		final n = test.length;
 		for (i in 0...allNodes.length) {
-			var node = allNodes[i];
+			final node = allNodes[i];
 			for (j in 0...n) {
 				// use JS native `startsWith`
 				if (untyped node.startsWith(test[j])) {
@@ -354,8 +354,8 @@ class Extractor
 	function resolveLib(name:String):LibTest
 	{
 		// libname=pattern
-		var parts = name.split('=');
-		var newName = parts[0];
+		final parts = name.split('=');
+		final newName = parts[0];
 		return {
 			test: parts[1].split(','),
 			roots: ({} :DynamicAccess<Bool>),
@@ -365,7 +365,7 @@ class Extractor
 
 	function addOnce(source:Array<String>, target:Array<String>)
 	{
-		var temp = target.copy();
+		final temp = target.copy();
 		for (node in source)
 			if (target.indexOf(node) < 0) temp.push(node);
 		return temp;

--- a/tool/src/HxSplit.hx
+++ b/tool/src/HxSplit.hx
@@ -14,7 +14,7 @@ class HxSplit
 		haxe.Log.trace = function(v, ?infos) { untyped console.log(v); };
 
 		// parse input
-		final src = Fs.readFileSync(input).toString();
+		final src = Fs.readFileSync(input, 'utf8');
 		final parser = new Parser(src, debugMode, commonjs);
 		final sourceMap = debugMode ? new SourceMap(input, src) : null;
 

--- a/tool/src/HxSplit.hx
+++ b/tool/src/HxSplit.hx
@@ -14,22 +14,22 @@ class HxSplit
 		haxe.Log.trace = function(v, ?infos) { untyped console.log(v); };
 
 		// parse input
-		var src = Fs.readFileSync(input).toString();
-		var parser = new Parser(src, debugMode, commonjs);
-		var sourceMap = debugMode ? new SourceMap(input, src) : null;
+		final src = Fs.readFileSync(input).toString();
+		final parser = new Parser(src, debugMode, commonjs);
+		final sourceMap = debugMode ? new SourceMap(input, src) : null;
 
 		// external hook
 		modules = applyAstHooks(parser.mainModule, modules, astHooks, parser.graph);
 
 		// process
 		if (debugSourceMap) dumpGraph(output, parser.graph);
-		var extractor = new Extractor(parser);
+		final extractor = new Extractor(parser);
 		extractor.process(parser.mainModule, modules, debugMode);
 
 		// emit
-		var reporter = new Reporter(dump);
-		var bundler = new Bundler(parser, sourceMap, extractor, reporter);
-		var result = bundler.generate(src, output, commonjs, debugSourceMap);
+		final reporter = new Reporter(dump);
+		final bundler = new Bundler(parser, sourceMap, extractor, reporter);
+		final result = bundler.generate(src, output, commonjs, debugSourceMap);
 
 		if (debugSourceMap) dumpModules(output, extractor);
 		if (dump) reporter.save(output);
@@ -42,7 +42,7 @@ class HxSplit
 		if (astHooks == null || astHooks.length == 0) return modules;
 		for (hook in astHooks) {
 			if (hook == null) continue;
-			var addModules = hook(graph, mainModule);
+			final addModules = hook(graph, mainModule);
 			if (addModules != null) modules = modules.concat(addModules);
 		}
 		return modules;
@@ -51,13 +51,13 @@ class HxSplit
 	static function dumpModules(output:String, extractor:Extractor)
 	{
 		trace('Dump bundles: ${output}.json');
-		var bundles = [extractor.main].concat(extractor.bundles);
+		final bundles = [extractor.main].concat(extractor.bundles);
 		for (bundle in bundles) {
 			Reflect.deleteField(bundle, 'indexes');
-			bundle.nodes.sort(function(s1, s2) return s1 == s2 ? 0 : s1 < s2 ? -1 : 1);
+			bundle.nodes.sort((s1, s2) -> s1 == s2 ? 0 : s1 < s2 ? -1 : 1);
 		}
 
-		var out = Json.stringify(bundles, '  ');
+		final out = Json.stringify(bundles, '  ');
 		Fs.writeFileSync(output + '.json', out);
 	}
 
@@ -67,15 +67,15 @@ class HxSplit
 		var out = '';
 		for (node in g.nodes()) {
 			if (node.charAt(0) != '$') {
-				var toNode = g.inEdges(node)
-					.map(function(n) return n.v.split('_').join('.'))
-					.filter(function(l) return l.charAt(0) != '$');
+				final toNode = g.inEdges(node)
+					.map(n -> n.v.split('_').join('.'))
+					.filter(l -> l.charAt(0) != '$');
 				if (toNode.length == 0)
 					continue;
 				out += '+ ${node} < ${toNode.join(', ')}\n';
-				var fromNode = g.outEdges(node)
-					.map(function(n) return n.w.split('_').join('.'))
-					.filter(function(l) return l.charAt(0) != '$');
+				final fromNode = g.outEdges(node)
+					.map(n -> n.w.split('_').join('.'))
+					.filter(l -> l.charAt(0) != '$');
 				for (dest in fromNode) {
 					out += '  - $dest\n';
 				}

--- a/tool/src/MinifyId.hx
+++ b/tool/src/MinifyId.hx
@@ -2,9 +2,9 @@ import haxe.DynamicAccess;
 
 class MinifyId
 {
-	static var BASE_16 = 'abcdefghijklmnop'.split('');
+	static final BASE_16 = 'abcdefghijklmnop'.split('');
 
-	var map:DynamicAccess<String> = {};
+	final map:DynamicAccess<String> = {};
 	var index:Int = 0;
 
 	public function new()
@@ -27,7 +27,7 @@ class MinifyId
 		if (id.length <= 2) return id;
 		var min = map.get(id);
 		if (min == null) {
-			var B16 = BASE_16;
+			final B16 = BASE_16;
 			var i = index++;
 			min = '';
 			while (i > 0xf) {

--- a/tool/src/Parser.hx
+++ b/tool/src/Parser.hx
@@ -18,7 +18,7 @@ class Parser
 		__map_reserved:true
 	};
 	var objectMethods:DynamicAccess<Bool> = {
-		'defineProperty':true, 'defineProperties':true, 'freeze':true
+		'defineProperty':true, 'defineProperties':true, 'freeze':true, 'assign': true
 	};
 
 	var types:DynamicAccess<Array<AstNode>>;
@@ -37,7 +37,7 @@ class Parser
 
 	function processInput(src:String, withLocation:Bool)
 	{
-		var options:AcornOptions = { ecmaVersion: 5, allowReserved: true };
+		var options:AcornOptions = { ecmaVersion: 6, allowReserved: true };
 		if (withLocation) options.locations = true;
 		var program = Acorn.parse(src, options);
 		walkProgram(program);
@@ -147,6 +147,8 @@ class Parser
 					inspectExpression(node.expression, node);
 				case 'FunctionDeclaration':
 					inspectFunction(node.id, node);
+				case 'ClassDeclaration':
+					inspectClass(node.id, node);
 				case 'IfStatement':
 					if (node.consequent.type == 'ExpressionStatement')
 						inspectExpression(node.consequent.expression, node);
@@ -179,6 +181,16 @@ class Parser
 		{
 			var name = path[0];
 			if (name == "$extend" || name == "$bind" || name == "$iterator") tag(name, def);
+		}
+	}
+
+	function inspectClass(id:AstNode, def:AstNode)
+	{
+		var path = getIdentifier(id);
+		if (path.length > 0)
+		{
+			var name = path[0];
+			tag(name, def);
 		}
 	}
 

--- a/tool/src/Parser.hx
+++ b/tool/src/Parser.hx
@@ -205,8 +205,7 @@ class Parser
 					var name = path[0];
 					switch (name)
 					{
-						case "$hx_exports":
-						case "$hxClasses":
+						case "$hxClasses", "$hx_exports":
 							var moduleName = getIdentifier(expression.right);
 							if (moduleName.length == 1) tag(moduleName[0], def);
 						default:
@@ -365,6 +364,8 @@ class Parser
 				return getIdentifier(left.object).concat(getIdentifier(left.property));
 			case 'Literal':
 				return [left.raw];
+			case 'AssignmentExpression':
+				return getIdentifier(left.right);
 			default:
 				return [];
 		}

--- a/tool/src/Reporter.hx
+++ b/tool/src/Reporter.hx
@@ -32,7 +32,7 @@ class Reporter
 		final raw = Json.stringify(stats, null, '  ');
 		Fs.writeFileSync(output + '.stats.json', raw);
 
-		final src = Fs.readFileSync(Path.join(Node.__dirname, 'viewer.js'));
+		final src = Fs.readFileSync(Path.join(Node.__dirname, 'viewer.js'), 'utf8');
 		final viewer = '<!DOCTYPE html><body><script>var __STATS__ = $raw;\n$src</script></body>';
 		Fs.writeFileSync(output + '.stats.html', viewer);
 	}

--- a/tool/src/Reporter.hx
+++ b/tool/src/Reporter.hx
@@ -14,9 +14,9 @@ typedef PackageStat = {
 
 class Reporter
 {
-	var stats:DynamicAccess<PackageStat>;
+	final stats:DynamicAccess<PackageStat>;
+	final enabled:Bool;
 	var current:PackageStat;
-	var enabled:Bool;
 
 	public function new(enabled:Bool)
 	{
@@ -29,11 +29,11 @@ class Reporter
 		if (!this.enabled) return;
 		trace('Size report: ${output}.stats.json');
 		calculate_rec(stats);
-		var raw = Json.stringify(stats, null, '  ');
+		final raw = Json.stringify(stats, null, '  ');
 		Fs.writeFileSync(output + '.stats.json', raw);
 
-		var src = Fs.readFileSync(Path.join(Node.__dirname, 'viewer.js'));
-		var viewer = '<!DOCTYPE html><body><script>var __STATS__ = $raw;\n$src</script></body>';
+		final src = Fs.readFileSync(Path.join(Node.__dirname, 'viewer.js'));
+		final viewer = '<!DOCTYPE html><body><script>var __STATS__ = $raw;\n$src</script></body>';
 		Fs.writeFileSync(output + '.stats.html', viewer);
 	}
 
@@ -44,7 +44,7 @@ class Reporter
 			total += group.get(key).size;
 		}
 		for (key in group.keys()) {
-			var node = group.get(key);
+			final node = group.get(key);
 			node.rel = Math.round(1000 * node.size / total) / 10;
 			if (node.group != null) calculate_rec(node.group);
 		}
@@ -75,7 +75,7 @@ class Reporter
 		if (!enabled) return;
 		current.size += size;
 		if (tag == null || tag == '__reserved__' || tag.charAt(0) == '$') return;
-		var parts = tag.indexOf("_$") < 0 ? tag.split('_') : safeSplit(tag);
+		final parts = tag.indexOf("_$") < 0 ? tag.split('_') : safeSplit(tag);
 		if (parts.length == 1) parts.unshift('TOPLEVEL');
 		var parent = current;
 		for (p in parts) {
@@ -92,10 +92,10 @@ class Reporter
 
 	function safeSplit(tag:String)
 	{
-		var p = [];
+		final p = [];
 		var acc = '';
 		for (i in 0...tag.length) {
-			var c = tag.charAt(i);
+			final c = tag.charAt(i);
 			if (c != '_') {
 				if (c != '$' || tag.charAt(i - 1) != '_') acc += c;
 			}

--- a/tool/src/SourceMap.hx
+++ b/tool/src/SourceMap.hx
@@ -1,6 +1,6 @@
 package;
 
-import acorn.Acorn.AstNode;
+import ast.AstNode;
 import js.node.Path;
 
 typedef SourceMapFile = {

--- a/tool/src/SourceMap.hx
+++ b/tool/src/SourceMap.hx
@@ -45,16 +45,16 @@ class SourceMap
 {
 	static public inline var SRC_REF = '//# sourceMappingURL=';
 
-	var fileName:String;
-	var source:DecodedSourceMapFile;
+	final fileName:String;
+	final source:DecodedSourceMapFile;
 	var lines:Array<String>;
 
 	public function new(input:String, src:String)
 	{
 		var p = src.lastIndexOf(SRC_REF);
 		if (p < 0) return;
-		fileName = StringTools.trim(src.substr(p + SRC_REF.length));
-		fileName = Path.join(Path.dirname(input), fileName);
+		final srcName = StringTools.trim(src.substr(p + SRC_REF.length));
+		fileName = Path.join(Path.dirname(input), srcName);
 		source = SM.decodeFile(fileName);
 	}
 
@@ -66,7 +66,7 @@ class SourceMap
 		if (nodes.length == 0 || source == null) return null;
 
 		// flag lines from original source that we want to include
-		var inc:Array<Null<Int>> = [];
+		final inc:Array<Null<Int>> = [];
 		var line = offset;
 		for (node in nodes)
 		{
@@ -75,8 +75,8 @@ class SourceMap
 		}
 
 		// new sourcemap
-		var output:Array<LineMapping> = [];
-		var map:DecodedSourceMapFile = {
+		final output:Array<LineMapping> = [];
+		final map:DecodedSourceMapFile = {
 			version: 3,
 			file: '',
 			sourceRoot: '',
@@ -85,11 +85,11 @@ class SourceMap
 			names: [],
 			mappings: null
 		};
-		var usedSources:Array<Bool> = [];
+		final usedSources:Array<Bool> = [];
 		try {
 			// filter mappings by flagged lines
-			var mappings = source.mappings;
-			var srcLength = mappings.length;
+			final mappings = source.mappings;
+			final srcLength = mappings.length;
 			var maxLine = 0;
 			for (i in 0...srcLength) {
 				var mapping:LineMapping = mappings[i];

--- a/tool/src/StatsViewer.hx
+++ b/tool/src/StatsViewer.hx
@@ -59,19 +59,19 @@ class StatsViewer
 {
 	static inline var MAX_DEPTH = 3;
 
-	var allGroups:Array<CarrotSearchFoamTreeGroup>;
-	var filtered:Array<CarrotSearchFoamTreeGroup> = [];
+	final allGroups:Array<CarrotSearchFoamTreeGroup>;
+	final filtered:Array<CarrotSearchFoamTreeGroup> = [];
 	var pendingFilter:Bool;
 	var pendingGroup:CarrotSearchFoamTreeGroup;
 	var totalSize:Int;
 
-	var tip:DivElement;
+	final tip:DivElement;
 	var tipWidth:Int;
 	var tipHeight:Int;
 	var delayResize:Timer;
 	var delayClick:Timer;
 
-	var foamtree:CarrotSearchFoamTree;
+	final foamtree:CarrotSearchFoamTree;
 
 	static function main()
 	{
@@ -80,10 +80,10 @@ class StatsViewer
 
 	public function new()
 	{
-		var stats = getStats();
+		final stats = getStats();
 		allGroups = formatData(stats);
 
-		var element = createElement();
+		final element = createElement();
 		tip = createTip();
 		tipWidth = 0;
 		tipHeight = 0;
@@ -95,7 +95,7 @@ class StatsViewer
 	{
 		window.addEventListener('resize', function(_) {
 			if (delayResize != null) return;
-			delayResize = Timer.delay(function() {
+			delayResize = Timer.delay(() -> {
 				delayResize = null;
 				foamtree.resize();
 			}, 300);
@@ -132,7 +132,7 @@ class StatsViewer
 
 	function createFoamTree(element:DivElement, groups:Array<CarrotSearchFoamTreeGroup>)
 	{
-		var ft = new CarrotSearchFoamTree({
+		final ft = new CarrotSearchFoamTree({
 			element: element,
 			layout: "squarified",
 			pixelRatio: window.devicePixelRatio != null ? window.devicePixelRatio : 1,
@@ -179,14 +179,14 @@ class StatsViewer
 		pendingGroup = group;
 
 		if (delayClick != null) return;
-		delayClick = Timer.delay(function() {
+		delayClick = Timer.delay(() -> {
 			delayClick = null;
 			if (pendingFilter) {
 				pendingFilter = false;
 				if (filtered.indexOf(pendingGroup) >= 0) return;
 				filtered.push(pendingGroup);
 				var groups = [pendingGroup];
-				Timer.delay(function() {
+				Timer.delay(() -> {
 					setDepth(groups);
 					foamtree.set('dataObject', { groups: groups });
 					window.history.pushState(null, pendingGroup.label);
@@ -199,8 +199,8 @@ class StatsViewer
 
 	function setDepth(groups:Array<CarrotSearchFoamTreeGroup>)
 	{
-		var count = countChildren(groups);
-		var value = MAX_DEPTH + Math.round(50 / count);
+		final count = countChildren(groups);
+		final value = MAX_DEPTH + Math.round(50 / count);
 		if (foamtree.get('maxGroupLevelsAttached') != value) {
 			foamtree.set('maxGroupLevelsDrawn', value);
 			foamtree.set('maxGroupLevelsAttached', value);
@@ -220,7 +220,7 @@ class StatsViewer
 
 	function updateTip(e:CarrotSearchFoamTreeEvent)
 	{
-		var o = e.group;
+		final o = e.group;
 		if (o == null) {
 			clearTip();
 			return;
@@ -278,7 +278,7 @@ class StatsViewer
 
 	function createTip()
 	{
-		var div = document.createDivElement();
+		final div = document.createDivElement();
 		div.style.position = 'absolute';
 		div.style.left = '0';
 		div.style.top = '0';
@@ -298,7 +298,7 @@ class StatsViewer
 
 	function createElement()
 	{
-		var div = document.createDivElement();
+		final div = document.createDivElement();
 		div.style.position = 'absolute';
 		div.style.left = '0';
 		div.style.top = '0';
@@ -310,10 +310,10 @@ class StatsViewer
 
 	function formatData(stats:DynamicAccess<PackageStat>, parent:CarrotSearchFoamTreeGroup = null)
 	{
-		var groups:Array<CarrotSearchFoamTreeGroup> = [];
+		final groups:Array<CarrotSearchFoamTreeGroup> = [];
         for (key in stats.keys()) {
-          var o = stats.get(key);
-          var it:CarrotSearchFoamTreeGroup = {
+          final o = stats.get(key);
+          final it:CarrotSearchFoamTreeGroup = {
             label: key,
             size: o.size,
             weight: o.rel,
@@ -328,10 +328,10 @@ class StatsViewer
 
 	function getStats():DynamicAccess<PackageStat>
 	{
-		var stats:DynamicAccess<PackageStat> = untyped __STATS__;
+		final stats:DynamicAccess<PackageStat> = untyped __STATS__;
 		var total = 0;
         for (key in stats.keys()) {
-          var o = stats.get(key);
+          final o = stats.get(key);
 		  total += o.size;
 		}
 		totalSize = total;

--- a/tool/src/ast/Acorn.hx
+++ b/tool/src/ast/Acorn.hx
@@ -1,4 +1,6 @@
-package acorn;
+package ast;
+
+import ast.AstNode;
 
 @:jsRequire('acorn')
 extern class Acorn
@@ -38,64 +40,6 @@ extern class Acorn
 	 * it will keep returning that same token forever.
 	 */
 	static public function tokenizer(input:String, options:AcornOptions):Tokenizer;
-}
-
-typedef AstPosition = {
-	line: Int,
-	column: Int
-}
-
-typedef AstSourceLocation = {
-	source: String,
-	start: AstPosition,
-	end: AstPosition
-}
-
-extern interface AstNode {
-	var __tag__: String;
-	var __main__: Bool;
-	var raw: String;
-	var type: String;
-	var loc: AstSourceLocation;
-	var source: String;
-	var start: Int;
-	var end: Int;
-	var range: Array<Int>;
-	var body: haxe.extern.EitherType<AstNode, Array<AstNode>>;
-	// ExpressionStatement
-	var expression: AstNode;
-	// CallExpression
-	var callee: AstNode;
-	var arguments: Array<AstNode>;
-	// FunctionExpression
-	var params: Array<AstNode>;
-	// Identifier
-	var name: String;
-	// Literal
-	var value: String;
-	var rawvar : String;
-	// ConditionalExpression/IfStatement
-	var test: AstNode;
-	var consequent: AstNode;
-	var alternate: AstNode;
-	// VariableDeclaration
-	var declarations: Array<AstNode>;
-	// VariableDeclarator
-	var id: AstNode;
-	var init: AstNode;
-	// AssignmentExpression
-	var left: AstNode;
-	var right: AstNode;
-	// LogicalExpression
-	@:native('operator') var op: String;
-	// MemberExpression
-	var object: AstNode;
-	var property: AstNode;
-	var computer: Bool;
-	// ObjectExpression
-	var properties: Array<AstNode>;
-	// Property
-	var key: AstNode;
 }
 
 typedef Tokenizer = {
@@ -196,7 +140,7 @@ typedef AcornOptions = {
 	@:optional var preserveParens:Bool;
 }
 
-@:jsRequire('acorn/dist/walk')
+@:jsRequire('acorn-walk')
 extern class Walk
 {
 	/**

--- a/tool/src/ast/AstNode.hx
+++ b/tool/src/ast/AstNode.hx
@@ -1,0 +1,59 @@
+package ast;
+
+typedef AstPosition = {
+	line: Int,
+	column: Int
+}
+
+typedef AstSourceLocation = {
+	source: String,
+	start: AstPosition,
+	end: AstPosition
+}
+
+extern interface AstNode {
+	var __tag__: String;
+	var __main__: Bool;
+	var raw: String;
+	var type: String;
+	var loc: AstSourceLocation;
+	var source: String;
+	var start: Int;
+	var end: Int;
+	var range: Array<Int>;
+	var body: haxe.extern.EitherType<AstNode, Array<AstNode>>;
+	// ExpressionStatement
+	var expression: AstNode;
+	// CallExpression
+	var callee: AstNode;
+	var arguments: Array<AstNode>;
+	// FunctionExpression
+	var params: Array<AstNode>;
+	// Identifier
+	var name: String;
+	// Literal
+	var value: String;
+	var rawvar : String;
+	// ConditionalExpression/IfStatement
+	var test: AstNode;
+	var consequent: AstNode;
+	var alternate: AstNode;
+	// VariableDeclaration
+	var declarations: Array<AstNode>;
+	// VariableDeclarator
+	var id: AstNode;
+	var init: AstNode;
+	// AssignmentExpression
+	var left: AstNode;
+	var right: AstNode;
+	// LogicalExpression
+	@:native('operator') var op: String;
+	// MemberExpression
+	var object: AstNode;
+	var property: AstNode;
+	var computer: Bool;
+	// ObjectExpression
+	var properties: Array<AstNode>;
+	// Property
+	var key: AstNode;
+}

--- a/tool/src/ast/Cherow.hx
+++ b/tool/src/ast/Cherow.hx
@@ -1,0 +1,26 @@
+package ast;
+
+import ast.AstNode;
+
+typedef CherowOptions = {
+	?module: Bool, // Enable module syntax
+	?loc: Bool, // Attach line/column location information to each node
+	?ranges: Bool, // Append start and end offsets to each node
+	?impliedStrict: Bool, // Enable strict mode initial enforcement
+	?next: Bool, // Enable stage 3 support (ESNext)
+	?tolerant: Bool, // Create a top-level error array containing all "skipped" errors
+	?source: Bool, // Set to true to record the source file in every node's loc object when the loc option is set.
+	?raw: Bool, // Attach raw property to each literal node
+	?rawIdentifier: Bool, // Attach raw property to each identifier node
+}
+
+@:jsRequire('cherow')
+extern class Cherow {
+
+	/**
+	 * is used to parse a JavaScript program. The input parameter is a string, options can
+	 * be undefined or an object setting some of the options listed below. The return value
+	 * will be an abstract syntax tree object as specified by the ESTree spec.
+	 */
+	static public function parse(input:String, options:CherowOptions):AstNode;
+}

--- a/tool/test/expect/haxe_3/node-debug-test13.json
+++ b/tool/test/expect/haxe_3/node-debug-test13.json
@@ -1,0 +1,35 @@
+[
+  {
+    "isMain": true,
+    "isLib": false,
+    "name": "Test13",
+    "nodes": [
+      "$hxClasses",
+      "Test13",
+      "Type"
+    ],
+    "exports": {
+      "$hxClasses": true
+    },
+    "shared": {
+      "a_$b_Exposed": true
+    },
+    "imports": {}
+  },
+  {
+    "isMain": false,
+    "isLib": false,
+    "name": "a_$b_Exposed",
+    "nodes": [
+      "a_$b_Exposed",
+      "a_$b_SubExposed"
+    ],
+    "exports": {
+      "a_$b_Exposed": true
+    },
+    "shared": {},
+    "imports": {
+      "$hxClasses": true
+    }
+  }
+]

--- a/tool/test/expect/haxe_3/node-debug-test14.json
+++ b/tool/test/expect/haxe_3/node-debug-test14.json
@@ -1,0 +1,29 @@
+[
+  {
+    "isMain": true,
+    "isLib": false,
+    "name": "Test14",
+    "nodes": [
+      "Test14"
+    ],
+    "exports": {},
+    "shared": {
+      "a_$b_Exposed": true
+    },
+    "imports": {}
+  },
+  {
+    "isMain": false,
+    "isLib": false,
+    "name": "a_$b_Exposed",
+    "nodes": [
+      "a_$b_Exposed",
+      "a_$b_SubExposed"
+    ],
+    "exports": {
+      "a_$b_Exposed": true
+    },
+    "shared": {},
+    "imports": {}
+  }
+]

--- a/tool/test/expect/haxe_3/node-release-test13.json
+++ b/tool/test/expect/haxe_3/node-release-test13.json
@@ -1,0 +1,35 @@
+[
+  {
+    "isMain": true,
+    "isLib": false,
+    "name": "Test13",
+    "nodes": [
+      "$hxClasses",
+      "Test13",
+      "Type"
+    ],
+    "exports": {
+      "$hxClasses": true
+    },
+    "shared": {
+      "a_$b_Exposed": true
+    },
+    "imports": {}
+  },
+  {
+    "isMain": false,
+    "isLib": false,
+    "name": "a_$b_Exposed",
+    "nodes": [
+      "a_$b_Exposed",
+      "a_$b_SubExposed"
+    ],
+    "exports": {
+      "a_$b_Exposed": true
+    },
+    "shared": {},
+    "imports": {
+      "$hxClasses": true
+    }
+  }
+]

--- a/tool/test/expect/haxe_3/node-release-test14.json
+++ b/tool/test/expect/haxe_3/node-release-test14.json
@@ -1,0 +1,29 @@
+[
+  {
+    "isMain": true,
+    "isLib": false,
+    "name": "Test14",
+    "nodes": [
+      "Test14"
+    ],
+    "exports": {},
+    "shared": {
+      "a_$b_Exposed": true
+    },
+    "imports": {}
+  },
+  {
+    "isMain": false,
+    "isLib": false,
+    "name": "a_$b_Exposed",
+    "nodes": [
+      "a_$b_Exposed",
+      "a_$b_SubExposed"
+    ],
+    "exports": {
+      "a_$b_Exposed": true
+    },
+    "shared": {},
+    "imports": {}
+  }
+]

--- a/tool/test/expect/haxe_3/web-debug-test13.json
+++ b/tool/test/expect/haxe_3/web-debug-test13.json
@@ -1,0 +1,42 @@
+[
+  {
+    "isMain": true,
+    "isLib": false,
+    "name": "Test13",
+    "nodes": [
+      "$hxClasses",
+      "Require",
+      "Std",
+      "Test13",
+      "Type",
+      "haxe_IMap",
+      "haxe_Timer",
+      "haxe_ds_StringMap",
+      "js_Boot",
+      "require"
+    ],
+    "exports": {
+      "$hxClasses": true
+    },
+    "shared": {
+      "a_$b_Exposed": true
+    },
+    "imports": {}
+  },
+  {
+    "isMain": false,
+    "isLib": false,
+    "name": "a_$b_Exposed",
+    "nodes": [
+      "a_$b_Exposed",
+      "a_$b_SubExposed"
+    ],
+    "exports": {
+      "a_$b_Exposed": true
+    },
+    "shared": {},
+    "imports": {
+      "$hxClasses": true
+    }
+  }
+]

--- a/tool/test/expect/haxe_3/web-debug-test14.json
+++ b/tool/test/expect/haxe_3/web-debug-test14.json
@@ -1,0 +1,36 @@
+[
+  {
+    "isMain": true,
+    "isLib": false,
+    "name": "Test14",
+    "nodes": [
+      "Require",
+      "Std",
+      "Test14",
+      "haxe_IMap",
+      "haxe_Timer",
+      "haxe_ds_StringMap",
+      "js_Boot",
+      "require"
+    ],
+    "exports": {},
+    "shared": {
+      "a_$b_Exposed": true
+    },
+    "imports": {}
+  },
+  {
+    "isMain": false,
+    "isLib": false,
+    "name": "a_$b_Exposed",
+    "nodes": [
+      "a_$b_Exposed",
+      "a_$b_SubExposed"
+    ],
+    "exports": {
+      "a_$b_Exposed": true
+    },
+    "shared": {},
+    "imports": {}
+  }
+]

--- a/tool/test/expect/haxe_3/web-release-test13.json
+++ b/tool/test/expect/haxe_3/web-release-test13.json
@@ -1,0 +1,39 @@
+[
+  {
+    "isMain": true,
+    "isLib": false,
+    "name": "Test13",
+    "nodes": [
+      "$hxClasses",
+      "Require",
+      "Test13",
+      "Type",
+      "haxe_IMap",
+      "haxe_ds_StringMap",
+      "require"
+    ],
+    "exports": {
+      "$hxClasses": true
+    },
+    "shared": {
+      "a_$b_Exposed": true
+    },
+    "imports": {}
+  },
+  {
+    "isMain": false,
+    "isLib": false,
+    "name": "a_$b_Exposed",
+    "nodes": [
+      "a_$b_Exposed",
+      "a_$b_SubExposed"
+    ],
+    "exports": {
+      "a_$b_Exposed": true
+    },
+    "shared": {},
+    "imports": {
+      "$hxClasses": true
+    }
+  }
+]

--- a/tool/test/expect/haxe_3/web-release-test14.json
+++ b/tool/test/expect/haxe_3/web-release-test14.json
@@ -1,0 +1,33 @@
+[
+  {
+    "isMain": true,
+    "isLib": false,
+    "name": "Test14",
+    "nodes": [
+      "Require",
+      "Test14",
+      "haxe_IMap",
+      "haxe_ds_StringMap",
+      "require"
+    ],
+    "exports": {},
+    "shared": {
+      "a_$b_Exposed": true
+    },
+    "imports": {}
+  },
+  {
+    "isMain": false,
+    "isLib": false,
+    "name": "a_$b_Exposed",
+    "nodes": [
+      "a_$b_Exposed",
+      "a_$b_SubExposed"
+    ],
+    "exports": {
+      "a_$b_Exposed": true
+    },
+    "shared": {},
+    "imports": {}
+  }
+]

--- a/tool/test/expect/haxe_4/node-debug-test13.json
+++ b/tool/test/expect/haxe_4/node-debug-test13.json
@@ -5,15 +5,7 @@
     "name": "Test13",
     "nodes": [
       "$hxClasses",
-      "Require",
-      "Std",
-      "Test13",
-      "haxe_IMap",
-      "haxe_Timer",
-      "haxe_ds_StringMap",
-      "js_Boot",
-      "js__$Boot_HaxeError",
-      "require"
+      "Test13"
     ],
     "exports": {
       "$hxClasses": true

--- a/tool/test/expect/haxe_4/node-debug-test14.json
+++ b/tool/test/expect/haxe_4/node-debug-test14.json
@@ -2,22 +2,11 @@
   {
     "isMain": true,
     "isLib": false,
-    "name": "Test13",
+    "name": "Test14",
     "nodes": [
-      "$hxClasses",
-      "Require",
-      "Std",
-      "Test13",
-      "haxe_IMap",
-      "haxe_Timer",
-      "haxe_ds_StringMap",
-      "js_Boot",
-      "js__$Boot_HaxeError",
-      "require"
+      "Test14"
     ],
-    "exports": {
-      "$hxClasses": true
-    },
+    "exports": {},
     "shared": {
       "a_$b_Exposed": true
     },
@@ -35,8 +24,6 @@
       "a_$b_Exposed": true
     },
     "shared": {},
-    "imports": {
-      "$hxClasses": true
-    }
+    "imports": {}
   }
 ]

--- a/tool/test/expect/haxe_4/node-release-test13.json
+++ b/tool/test/expect/haxe_4/node-release-test13.json
@@ -5,15 +5,7 @@
     "name": "Test13",
     "nodes": [
       "$hxClasses",
-      "Require",
-      "Std",
-      "Test13",
-      "haxe_IMap",
-      "haxe_Timer",
-      "haxe_ds_StringMap",
-      "js_Boot",
-      "js__$Boot_HaxeError",
-      "require"
+      "Test13"
     ],
     "exports": {
       "$hxClasses": true

--- a/tool/test/expect/haxe_4/node-release-test14.json
+++ b/tool/test/expect/haxe_4/node-release-test14.json
@@ -2,22 +2,11 @@
   {
     "isMain": true,
     "isLib": false,
-    "name": "Test13",
+    "name": "Test14",
     "nodes": [
-      "$hxClasses",
-      "Require",
-      "Std",
-      "Test13",
-      "haxe_IMap",
-      "haxe_Timer",
-      "haxe_ds_StringMap",
-      "js_Boot",
-      "js__$Boot_HaxeError",
-      "require"
+      "Test14"
     ],
-    "exports": {
-      "$hxClasses": true
-    },
+    "exports": {},
     "shared": {
       "a_$b_Exposed": true
     },
@@ -35,8 +24,6 @@
       "a_$b_Exposed": true
     },
     "shared": {},
-    "imports": {
-      "$hxClasses": true
-    }
+    "imports": {}
   }
 ]

--- a/tool/test/expect/haxe_4/web-debug-test13.json
+++ b/tool/test/expect/haxe_4/web-debug-test13.json
@@ -4,6 +4,7 @@
     "isLib": false,
     "name": "Test13",
     "nodes": [
+      "$extend",
       "$hxClasses",
       "Require",
       "Std",

--- a/tool/test/expect/haxe_4/web-debug-test14.json
+++ b/tool/test/expect/haxe_4/web-debug-test14.json
@@ -2,22 +2,19 @@
   {
     "isMain": true,
     "isLib": false,
-    "name": "Test13",
+    "name": "Test14",
     "nodes": [
-      "$hxClasses",
+      "$extend",
       "Require",
       "Std",
-      "Test13",
-      "haxe_IMap",
+      "Test14",
       "haxe_Timer",
       "haxe_ds_StringMap",
       "js_Boot",
       "js__$Boot_HaxeError",
       "require"
     ],
-    "exports": {
-      "$hxClasses": true
-    },
+    "exports": {},
     "shared": {
       "a_$b_Exposed": true
     },
@@ -35,8 +32,6 @@
       "a_$b_Exposed": true
     },
     "shared": {},
-    "imports": {
-      "$hxClasses": true
-    }
+    "imports": {}
   }
 ]

--- a/tool/test/expect/haxe_4/web-release-test13.json
+++ b/tool/test/expect/haxe_4/web-release-test13.json
@@ -6,13 +6,9 @@
     "nodes": [
       "$hxClasses",
       "Require",
-      "Std",
       "Test13",
       "haxe_IMap",
-      "haxe_Timer",
       "haxe_ds_StringMap",
-      "js_Boot",
-      "js__$Boot_HaxeError",
       "require"
     ],
     "exports": {

--- a/tool/test/expect/haxe_4/web-release-test14.json
+++ b/tool/test/expect/haxe_4/web-release-test14.json
@@ -2,22 +2,14 @@
   {
     "isMain": true,
     "isLib": false,
-    "name": "Test13",
+    "name": "Test14",
     "nodes": [
-      "$hxClasses",
       "Require",
-      "Std",
-      "Test13",
-      "haxe_IMap",
-      "haxe_Timer",
+      "Test14",
       "haxe_ds_StringMap",
-      "js_Boot",
-      "js__$Boot_HaxeError",
       "require"
     ],
-    "exports": {
-      "$hxClasses": true
-    },
+    "exports": {},
     "shared": {
       "a_$b_Exposed": true
     },
@@ -35,8 +27,6 @@
       "a_$b_Exposed": true
     },
     "shared": {},
-    "imports": {
-      "$hxClasses": true
-    }
+    "imports": {}
   }
 ]

--- a/tool/test/expect/haxe_4_es6/node-debug-test1.json
+++ b/tool/test/expect/haxe_4_es6/node-debug-test1.json
@@ -1,0 +1,62 @@
+[
+  {
+    "isMain": true,
+    "isLib": false,
+    "name": "Test1",
+    "nodes": [
+      "$estr",
+      "$hxClasses",
+      "$hxEnums",
+      "DepAB",
+      "DepDepAB",
+      "DepDepB",
+      "Test1",
+      "js_Boot",
+      "js__$Boot_HaxeError"
+    ],
+    "exports": {
+      "DepAB": true,
+      "$hxClasses": true,
+      "DepDepB": true
+    },
+    "shared": {
+      "CaseA": true,
+      "CaseB": true
+    },
+    "imports": {}
+  },
+  {
+    "isMain": false,
+    "isLib": false,
+    "name": "CaseA",
+    "nodes": [
+      "CaseA"
+    ],
+    "exports": {
+      "CaseA": true
+    },
+    "shared": {},
+    "imports": {
+      "DepAB": true,
+      "$hxClasses": true
+    }
+  },
+  {
+    "isMain": false,
+    "isLib": false,
+    "name": "CaseB",
+    "nodes": [
+      "CaseB",
+      "DepB"
+    ],
+    "exports": {
+      "CaseB": true
+    },
+    "shared": {},
+    "imports": {
+      "DepAB": true,
+      "DepDepB": true,
+      "$hxClasses": true
+    }
+  }
+]

--- a/tool/test/expect/haxe_4_es6/node-debug-test10.json
+++ b/tool/test/expect/haxe_4_es6/node-debug-test10.json
@@ -1,0 +1,55 @@
+[
+  {
+    "isMain": true,
+    "isLib": false,
+    "name": "Test10",
+    "nodes": [
+      "$hxClasses",
+      "Test10",
+      "Test10"
+    ],
+    "exports": {
+      "Test10": true,
+      "$hxClasses": true
+    },
+    "shared": {
+      "CaseE": true
+    },
+    "imports": {}
+  },
+  {
+    "isMain": false,
+    "isLib": false,
+    "name": "CaseE",
+    "nodes": [
+      "CaseE"
+    ],
+    "exports": {
+      "CaseE": true
+    },
+    "shared": {
+      "DepE": true
+    },
+    "imports": {
+      "Test10": true,
+      "$hxClasses": true
+    }
+  },
+  {
+    "isMain": false,
+    "isLib": false,
+    "name": "DepE",
+    "nodes": [
+      "DepE"
+    ],
+    "exports": {
+      "DepE": true
+    },
+    "shared": {},
+    "imports": {
+      "CaseE": true,
+      "Test10": true,
+      "$hxClasses": true
+    }
+  }
+]

--- a/tool/test/expect/haxe_4_es6/node-debug-test11.json
+++ b/tool/test/expect/haxe_4_es6/node-debug-test11.json
@@ -1,0 +1,34 @@
+[
+  {
+    "isMain": true,
+    "isLib": false,
+    "name": "Test11",
+    "nodes": [
+      "$hxClasses",
+      "Test11"
+    ],
+    "exports": {
+      "$hxClasses": true
+    },
+    "shared": {
+      "CaseF": true
+    },
+    "imports": {}
+  },
+  {
+    "isMain": false,
+    "isLib": false,
+    "name": "CaseF",
+    "nodes": [
+      "CaseF",
+      "js__$Boot_HaxeError"
+    ],
+    "exports": {
+      "CaseF": true
+    },
+    "shared": {},
+    "imports": {
+      "$hxClasses": true
+    }
+  }
+]

--- a/tool/test/expect/haxe_4_es6/node-debug-test12.json
+++ b/tool/test/expect/haxe_4_es6/node-debug-test12.json
@@ -1,0 +1,42 @@
+[
+  {
+    "isMain": true,
+    "isLib": false,
+    "name": "Test12",
+    "nodes": [
+      "$hxClasses",
+      "DepDepMain",
+      "DepMain",
+      "Require",
+      "Test12",
+      "haxe_IMap",
+      "haxe_ds_StringMap"
+    ],
+    "exports": {
+      "$hxClasses": true
+    },
+    "shared": {
+      "lib_Lib2": true,
+      "a_$b_C_$_$d": true
+    },
+    "imports": {}
+  },
+  {
+    "isMain": false,
+    "isLib": true,
+    "name": "lib",
+    "nodes": [
+      "a_$b_C_$_$d",
+      "lib_DepLib",
+      "lib_Lib2"
+    ],
+    "exports": {
+      "lib_Lib2": true,
+      "a_$b_C_$_$d": true
+    },
+    "shared": {},
+    "imports": {
+      "$hxClasses": true
+    }
+  }
+]

--- a/tool/test/expect/haxe_4_es6/node-debug-test13.json
+++ b/tool/test/expect/haxe_4_es6/node-debug-test13.json
@@ -5,15 +5,7 @@
     "name": "Test13",
     "nodes": [
       "$hxClasses",
-      "Require",
-      "Std",
-      "Test13",
-      "haxe_IMap",
-      "haxe_Timer",
-      "haxe_ds_StringMap",
-      "js_Boot",
-      "js__$Boot_HaxeError",
-      "require"
+      "Test13"
     ],
     "exports": {
       "$hxClasses": true

--- a/tool/test/expect/haxe_4_es6/node-debug-test14.json
+++ b/tool/test/expect/haxe_4_es6/node-debug-test14.json
@@ -2,22 +2,11 @@
   {
     "isMain": true,
     "isLib": false,
-    "name": "Test13",
+    "name": "Test14",
     "nodes": [
-      "$hxClasses",
-      "Require",
-      "Std",
-      "Test13",
-      "haxe_IMap",
-      "haxe_Timer",
-      "haxe_ds_StringMap",
-      "js_Boot",
-      "js__$Boot_HaxeError",
-      "require"
+      "Test14"
     ],
-    "exports": {
-      "$hxClasses": true
-    },
+    "exports": {},
     "shared": {
       "a_$b_Exposed": true
     },
@@ -35,8 +24,6 @@
       "a_$b_Exposed": true
     },
     "shared": {},
-    "imports": {
-      "$hxClasses": true
-    }
+    "imports": {}
   }
 ]

--- a/tool/test/expect/haxe_4_es6/node-debug-test2.json
+++ b/tool/test/expect/haxe_4_es6/node-debug-test2.json
@@ -1,0 +1,62 @@
+[
+  {
+    "isMain": true,
+    "isLib": false,
+    "name": "Test2",
+    "nodes": [
+      "$estr",
+      "$hxClasses",
+      "$hxEnums",
+      "DepAB",
+      "DepDepAB",
+      "DepDepB",
+      "Test2",
+      "js_Boot",
+      "js__$Boot_HaxeError"
+    ],
+    "exports": {
+      "DepAB": true,
+      "$hxClasses": true,
+      "DepDepB": true
+    },
+    "shared": {
+      "CaseA": true,
+      "CaseB": true
+    },
+    "imports": {}
+  },
+  {
+    "isMain": false,
+    "isLib": false,
+    "name": "CaseA",
+    "nodes": [
+      "CaseA"
+    ],
+    "exports": {
+      "CaseA": true
+    },
+    "shared": {},
+    "imports": {
+      "DepAB": true,
+      "$hxClasses": true
+    }
+  },
+  {
+    "isMain": false,
+    "isLib": false,
+    "name": "CaseB",
+    "nodes": [
+      "CaseB",
+      "DepB"
+    ],
+    "exports": {
+      "CaseB": true
+    },
+    "shared": {},
+    "imports": {
+      "DepAB": true,
+      "DepDepB": true,
+      "$hxClasses": true
+    }
+  }
+]

--- a/tool/test/expect/haxe_4_es6/node-debug-test3.json
+++ b/tool/test/expect/haxe_4_es6/node-debug-test3.json
@@ -1,0 +1,91 @@
+[
+  {
+    "isMain": true,
+    "isLib": false,
+    "name": "Test3",
+    "nodes": [
+      "$hxClasses",
+      "DepDepMain",
+      "DepMain",
+      "Test3"
+    ],
+    "exports": {
+      "DepMain": true,
+      "$hxClasses": true
+    },
+    "shared": {
+      "CaseC": true
+    },
+    "imports": {}
+  },
+  {
+    "isMain": false,
+    "isLib": false,
+    "name": "CaseC",
+    "nodes": [
+      "CaseC"
+    ],
+    "exports": {
+      "CaseC": true
+    },
+    "shared": {
+      "DepC": true
+    },
+    "imports": {
+      "$hxClasses": true
+    }
+  },
+  {
+    "isMain": false,
+    "isLib": false,
+    "name": "DepC",
+    "nodes": [
+      "DepC",
+      "DepSubC"
+    ],
+    "exports": {
+      "DepC": true,
+      "DepSubC": true
+    },
+    "shared": {
+      "SubC": true,
+      "SubC2": true
+    },
+    "imports": {
+      "DepMain": true,
+      "$hxClasses": true
+    }
+  },
+  {
+    "isMain": false,
+    "isLib": false,
+    "name": "SubC",
+    "nodes": [
+      "SubC"
+    ],
+    "exports": {
+      "SubC": true
+    },
+    "shared": {},
+    "imports": {
+      "DepSubC": true,
+      "$hxClasses": true
+    }
+  },
+  {
+    "isMain": false,
+    "isLib": false,
+    "name": "SubC2",
+    "nodes": [
+      "SubC2"
+    ],
+    "exports": {
+      "SubC2": true
+    },
+    "shared": {},
+    "imports": {
+      "DepSubC": true,
+      "$hxClasses": true
+    }
+  }
+]

--- a/tool/test/expect/haxe_4_es6/node-debug-test4.json
+++ b/tool/test/expect/haxe_4_es6/node-debug-test4.json
@@ -1,0 +1,87 @@
+[
+  {
+    "isMain": true,
+    "isLib": false,
+    "name": "Test4",
+    "nodes": [
+      "$estr",
+      "$hxClasses",
+      "$hxEnums",
+      "DepAB",
+      "DepDepAB",
+      "DepDepB",
+      "DepDepMain",
+      "DepMain",
+      "Require",
+      "Test4",
+      "haxe_IMap",
+      "haxe_ds_StringMap",
+      "js_Boot",
+      "js__$Boot_HaxeError"
+    ],
+    "exports": {
+      "DepAB": true,
+      "$hxClasses": true,
+      "DepDepB": true
+    },
+    "shared": {
+      "CaseA": true,
+      "CaseB": true
+    },
+    "imports": {}
+  },
+  {
+    "isMain": false,
+    "isLib": false,
+    "name": "CaseA",
+    "nodes": [
+      "CaseA"
+    ],
+    "exports": {
+      "CaseA": true
+    },
+    "shared": {},
+    "imports": {
+      "DepAB": true,
+      "lib_Lib": true,
+      "$hxClasses": true
+    }
+  },
+  {
+    "isMain": false,
+    "isLib": false,
+    "name": "CaseB",
+    "nodes": [
+      "CaseB",
+      "DepB"
+    ],
+    "exports": {
+      "CaseB": true
+    },
+    "shared": {},
+    "imports": {
+      "DepAB": true,
+      "DepDepB": true,
+      "$hxClasses": true,
+      "lib_Lib2": true
+    }
+  },
+  {
+    "isMain": false,
+    "isLib": true,
+    "name": "lib",
+    "nodes": [
+      "lib_DepLib",
+      "lib_Lib",
+      "lib_Lib2"
+    ],
+    "exports": {
+      "lib_Lib": true,
+      "lib_Lib2": true
+    },
+    "shared": {},
+    "imports": {
+      "$hxClasses": true
+    }
+  }
+]

--- a/tool/test/expect/haxe_4_es6/node-debug-test5.json
+++ b/tool/test/expect/haxe_4_es6/node-debug-test5.json
@@ -1,0 +1,91 @@
+[
+  {
+    "isMain": true,
+    "isLib": false,
+    "name": "Test5",
+    "nodes": [
+      "$estr",
+      "$hxClasses",
+      "$hxEnums",
+      "DepAB",
+      "DepDepAB",
+      "DepDepB",
+      "DepDepMain",
+      "DepMain",
+      "Require",
+      "Test5",
+      "haxe_IMap",
+      "haxe_ds_StringMap",
+      "js_Boot",
+      "js__$Boot_HaxeError"
+    ],
+    "exports": {
+      "$hxClasses": true,
+      "DepAB": true,
+      "DepDepB": true
+    },
+    "shared": {
+      "lib_Lib2": true,
+      "a_$b_C_$_$d": true,
+      "CaseA": true,
+      "CaseB": true
+    },
+    "imports": {}
+  },
+  {
+    "isMain": false,
+    "isLib": false,
+    "name": "CaseA",
+    "nodes": [
+      "CaseA"
+    ],
+    "exports": {
+      "CaseA": true
+    },
+    "shared": {},
+    "imports": {
+      "DepAB": true,
+      "lib_Lib": true,
+      "$hxClasses": true
+    }
+  },
+  {
+    "isMain": false,
+    "isLib": false,
+    "name": "CaseB",
+    "nodes": [
+      "CaseB",
+      "DepB"
+    ],
+    "exports": {
+      "CaseB": true
+    },
+    "shared": {},
+    "imports": {
+      "DepAB": true,
+      "DepDepB": true,
+      "$hxClasses": true,
+      "lib_Lib2": true
+    }
+  },
+  {
+    "isMain": false,
+    "isLib": true,
+    "name": "lib",
+    "nodes": [
+      "a_$b_C_$_$d",
+      "lib_DepLib",
+      "lib_Lib",
+      "lib_Lib2"
+    ],
+    "exports": {
+      "lib_Lib2": true,
+      "a_$b_C_$_$d": true,
+      "lib_Lib": true
+    },
+    "shared": {},
+    "imports": {
+      "$hxClasses": true
+    }
+  }
+]

--- a/tool/test/expect/haxe_4_es6/node-debug-test6.json
+++ b/tool/test/expect/haxe_4_es6/node-debug-test6.json
@@ -1,0 +1,37 @@
+[
+  {
+    "isMain": true,
+    "isLib": false,
+    "name": "Test6",
+    "nodes": [
+      "$hxClasses",
+      "Reflected",
+      "Test6",
+      "Type"
+    ],
+    "exports": {
+      "$hxClasses": true
+    },
+    "shared": {
+      "CaseA": true
+    },
+    "imports": {}
+  },
+  {
+    "isMain": false,
+    "isLib": false,
+    "name": "CaseA",
+    "nodes": [
+      "CaseA",
+      "DepAB",
+      "DepDepAB"
+    ],
+    "exports": {
+      "CaseA": true
+    },
+    "shared": {},
+    "imports": {
+      "$hxClasses": true
+    }
+  }
+]

--- a/tool/test/expect/haxe_4_es6/node-debug-test7.json
+++ b/tool/test/expect/haxe_4_es6/node-debug-test7.json
@@ -1,0 +1,34 @@
+[
+  {
+    "isMain": true,
+    "isLib": false,
+    "name": "Test7",
+    "nodes": [
+      "$hxClasses",
+      "Test7"
+    ],
+    "exports": {
+      "$hxClasses": true
+    },
+    "shared": {
+      "CaseD": true
+    },
+    "imports": {}
+  },
+  {
+    "isMain": false,
+    "isLib": false,
+    "name": "CaseD",
+    "nodes": [
+      "CaseD",
+      "CycleD"
+    ],
+    "exports": {
+      "CaseD": true
+    },
+    "shared": {},
+    "imports": {
+      "$hxClasses": true
+    }
+  }
+]

--- a/tool/test/expect/haxe_4_es6/node-debug-test8.json
+++ b/tool/test/expect/haxe_4_es6/node-debug-test8.json
@@ -1,0 +1,14 @@
+[
+  {
+    "isMain": true,
+    "isLib": false,
+    "name": "Test8",
+    "nodes": [
+      "$hxClasses",
+      "Test8"
+    ],
+    "exports": {},
+    "shared": {},
+    "imports": {}
+  }
+]

--- a/tool/test/expect/haxe_4_es6/node-debug-test9.json
+++ b/tool/test/expect/haxe_4_es6/node-debug-test9.json
@@ -1,0 +1,33 @@
+[
+  {
+    "isMain": true,
+    "isLib": false,
+    "name": "Test9",
+    "nodes": [
+      "$hxClasses",
+      "Test9"
+    ],
+    "exports": {
+      "$hxClasses": true
+    },
+    "shared": {
+      "CaseD": true
+    },
+    "imports": {}
+  },
+  {
+    "isMain": false,
+    "isLib": false,
+    "name": "CaseD",
+    "nodes": [
+      "CaseD"
+    ],
+    "exports": {
+      "CaseD": true
+    },
+    "shared": {},
+    "imports": {
+      "$hxClasses": true
+    }
+  }
+]

--- a/tool/test/expect/haxe_4_es6/node-release-test1.json
+++ b/tool/test/expect/haxe_4_es6/node-release-test1.json
@@ -1,0 +1,64 @@
+[
+  {
+    "isMain": true,
+    "isLib": false,
+    "name": "Test1",
+    "nodes": [
+      "$estr",
+      "$hxClasses",
+      "$hxEnums",
+      "DepAB",
+      "DepDepAB",
+      "Test1",
+      "js_Boot",
+      "js__$Boot_HaxeError"
+    ],
+    "exports": {
+      "DepAB": true,
+      "$hxClasses": true,
+      "$estr": true,
+      "$hxEnums": true
+    },
+    "shared": {
+      "CaseA": true,
+      "CaseB": true
+    },
+    "imports": {}
+  },
+  {
+    "isMain": false,
+    "isLib": false,
+    "name": "CaseA",
+    "nodes": [
+      "CaseA"
+    ],
+    "exports": {
+      "CaseA": true
+    },
+    "shared": {},
+    "imports": {
+      "DepAB": true,
+      "$hxClasses": true
+    }
+  },
+  {
+    "isMain": false,
+    "isLib": false,
+    "name": "CaseB",
+    "nodes": [
+      "CaseB",
+      "DepB",
+      "DepDepB"
+    ],
+    "exports": {
+      "CaseB": true
+    },
+    "shared": {},
+    "imports": {
+      "DepAB": true,
+      "$estr": true,
+      "$hxEnums": true,
+      "$hxClasses": true
+    }
+  }
+]

--- a/tool/test/expect/haxe_4_es6/node-release-test10.json
+++ b/tool/test/expect/haxe_4_es6/node-release-test10.json
@@ -1,0 +1,55 @@
+[
+  {
+    "isMain": true,
+    "isLib": false,
+    "name": "Test10",
+    "nodes": [
+      "$hxClasses",
+      "Test10",
+      "Test10"
+    ],
+    "exports": {
+      "Test10": true,
+      "$hxClasses": true
+    },
+    "shared": {
+      "CaseE": true
+    },
+    "imports": {}
+  },
+  {
+    "isMain": false,
+    "isLib": false,
+    "name": "CaseE",
+    "nodes": [
+      "CaseE"
+    ],
+    "exports": {
+      "CaseE": true
+    },
+    "shared": {
+      "DepE": true
+    },
+    "imports": {
+      "Test10": true,
+      "$hxClasses": true
+    }
+  },
+  {
+    "isMain": false,
+    "isLib": false,
+    "name": "DepE",
+    "nodes": [
+      "DepE"
+    ],
+    "exports": {
+      "DepE": true
+    },
+    "shared": {},
+    "imports": {
+      "CaseE": true,
+      "Test10": true,
+      "$hxClasses": true
+    }
+  }
+]

--- a/tool/test/expect/haxe_4_es6/node-release-test11.json
+++ b/tool/test/expect/haxe_4_es6/node-release-test11.json
@@ -1,0 +1,34 @@
+[
+  {
+    "isMain": true,
+    "isLib": false,
+    "name": "Test11",
+    "nodes": [
+      "$hxClasses",
+      "Test11"
+    ],
+    "exports": {
+      "$hxClasses": true
+    },
+    "shared": {
+      "CaseF": true
+    },
+    "imports": {}
+  },
+  {
+    "isMain": false,
+    "isLib": false,
+    "name": "CaseF",
+    "nodes": [
+      "CaseF",
+      "js__$Boot_HaxeError"
+    ],
+    "exports": {
+      "CaseF": true
+    },
+    "shared": {},
+    "imports": {
+      "$hxClasses": true
+    }
+  }
+]

--- a/tool/test/expect/haxe_4_es6/node-release-test12.json
+++ b/tool/test/expect/haxe_4_es6/node-release-test12.json
@@ -1,0 +1,42 @@
+[
+  {
+    "isMain": true,
+    "isLib": false,
+    "name": "Test12",
+    "nodes": [
+      "$hxClasses",
+      "DepDepMain",
+      "DepMain",
+      "Require",
+      "Test12",
+      "haxe_IMap",
+      "haxe_ds_StringMap"
+    ],
+    "exports": {
+      "$hxClasses": true
+    },
+    "shared": {
+      "lib_Lib2": true,
+      "a_$b_C_$_$d": true
+    },
+    "imports": {}
+  },
+  {
+    "isMain": false,
+    "isLib": true,
+    "name": "lib",
+    "nodes": [
+      "a_$b_C_$_$d",
+      "lib_DepLib",
+      "lib_Lib2"
+    ],
+    "exports": {
+      "lib_Lib2": true,
+      "a_$b_C_$_$d": true
+    },
+    "shared": {},
+    "imports": {
+      "$hxClasses": true
+    }
+  }
+]

--- a/tool/test/expect/haxe_4_es6/node-release-test13.json
+++ b/tool/test/expect/haxe_4_es6/node-release-test13.json
@@ -5,15 +5,7 @@
     "name": "Test13",
     "nodes": [
       "$hxClasses",
-      "Require",
-      "Std",
-      "Test13",
-      "haxe_IMap",
-      "haxe_Timer",
-      "haxe_ds_StringMap",
-      "js_Boot",
-      "js__$Boot_HaxeError",
-      "require"
+      "Test13"
     ],
     "exports": {
       "$hxClasses": true

--- a/tool/test/expect/haxe_4_es6/node-release-test14.json
+++ b/tool/test/expect/haxe_4_es6/node-release-test14.json
@@ -2,22 +2,11 @@
   {
     "isMain": true,
     "isLib": false,
-    "name": "Test13",
+    "name": "Test14",
     "nodes": [
-      "$hxClasses",
-      "Require",
-      "Std",
-      "Test13",
-      "haxe_IMap",
-      "haxe_Timer",
-      "haxe_ds_StringMap",
-      "js_Boot",
-      "js__$Boot_HaxeError",
-      "require"
+      "Test14"
     ],
-    "exports": {
-      "$hxClasses": true
-    },
+    "exports": {},
     "shared": {
       "a_$b_Exposed": true
     },
@@ -35,8 +24,6 @@
       "a_$b_Exposed": true
     },
     "shared": {},
-    "imports": {
-      "$hxClasses": true
-    }
+    "imports": {}
   }
 ]

--- a/tool/test/expect/haxe_4_es6/node-release-test2.json
+++ b/tool/test/expect/haxe_4_es6/node-release-test2.json
@@ -1,0 +1,64 @@
+[
+  {
+    "isMain": true,
+    "isLib": false,
+    "name": "Test2",
+    "nodes": [
+      "$estr",
+      "$hxClasses",
+      "$hxEnums",
+      "DepAB",
+      "DepDepAB",
+      "Test2",
+      "js_Boot",
+      "js__$Boot_HaxeError"
+    ],
+    "exports": {
+      "DepAB": true,
+      "$hxClasses": true,
+      "$estr": true,
+      "$hxEnums": true
+    },
+    "shared": {
+      "CaseA": true,
+      "CaseB": true
+    },
+    "imports": {}
+  },
+  {
+    "isMain": false,
+    "isLib": false,
+    "name": "CaseA",
+    "nodes": [
+      "CaseA"
+    ],
+    "exports": {
+      "CaseA": true
+    },
+    "shared": {},
+    "imports": {
+      "DepAB": true,
+      "$hxClasses": true
+    }
+  },
+  {
+    "isMain": false,
+    "isLib": false,
+    "name": "CaseB",
+    "nodes": [
+      "CaseB",
+      "DepB",
+      "DepDepB"
+    ],
+    "exports": {
+      "CaseB": true
+    },
+    "shared": {},
+    "imports": {
+      "DepAB": true,
+      "$estr": true,
+      "$hxEnums": true,
+      "$hxClasses": true
+    }
+  }
+]

--- a/tool/test/expect/haxe_4_es6/node-release-test3.json
+++ b/tool/test/expect/haxe_4_es6/node-release-test3.json
@@ -1,0 +1,91 @@
+[
+  {
+    "isMain": true,
+    "isLib": false,
+    "name": "Test3",
+    "nodes": [
+      "$hxClasses",
+      "DepDepMain",
+      "DepMain",
+      "Test3"
+    ],
+    "exports": {
+      "DepMain": true,
+      "$hxClasses": true
+    },
+    "shared": {
+      "CaseC": true
+    },
+    "imports": {}
+  },
+  {
+    "isMain": false,
+    "isLib": false,
+    "name": "CaseC",
+    "nodes": [
+      "CaseC"
+    ],
+    "exports": {
+      "CaseC": true
+    },
+    "shared": {
+      "DepC": true
+    },
+    "imports": {
+      "$hxClasses": true
+    }
+  },
+  {
+    "isMain": false,
+    "isLib": false,
+    "name": "DepC",
+    "nodes": [
+      "DepC",
+      "DepSubC"
+    ],
+    "exports": {
+      "DepC": true,
+      "DepSubC": true
+    },
+    "shared": {
+      "SubC": true,
+      "SubC2": true
+    },
+    "imports": {
+      "DepMain": true,
+      "$hxClasses": true
+    }
+  },
+  {
+    "isMain": false,
+    "isLib": false,
+    "name": "SubC",
+    "nodes": [
+      "SubC"
+    ],
+    "exports": {
+      "SubC": true
+    },
+    "shared": {},
+    "imports": {
+      "DepSubC": true,
+      "$hxClasses": true
+    }
+  },
+  {
+    "isMain": false,
+    "isLib": false,
+    "name": "SubC2",
+    "nodes": [
+      "SubC2"
+    ],
+    "exports": {
+      "SubC2": true
+    },
+    "shared": {},
+    "imports": {
+      "DepSubC": true,
+      "$hxClasses": true
+    }
+  }
+]

--- a/tool/test/expect/haxe_4_es6/node-release-test4.json
+++ b/tool/test/expect/haxe_4_es6/node-release-test4.json
@@ -1,0 +1,89 @@
+[
+  {
+    "isMain": true,
+    "isLib": false,
+    "name": "Test4",
+    "nodes": [
+      "$estr",
+      "$hxClasses",
+      "$hxEnums",
+      "DepAB",
+      "DepDepAB",
+      "DepDepMain",
+      "DepMain",
+      "Require",
+      "Test4",
+      "haxe_IMap",
+      "haxe_ds_StringMap",
+      "js_Boot",
+      "js__$Boot_HaxeError"
+    ],
+    "exports": {
+      "DepAB": true,
+      "$hxClasses": true,
+      "$estr": true,
+      "$hxEnums": true
+    },
+    "shared": {
+      "CaseA": true,
+      "CaseB": true
+    },
+    "imports": {}
+  },
+  {
+    "isMain": false,
+    "isLib": false,
+    "name": "CaseA",
+    "nodes": [
+      "CaseA"
+    ],
+    "exports": {
+      "CaseA": true
+    },
+    "shared": {},
+    "imports": {
+      "DepAB": true,
+      "lib_Lib": true,
+      "$hxClasses": true
+    }
+  },
+  {
+    "isMain": false,
+    "isLib": false,
+    "name": "CaseB",
+    "nodes": [
+      "CaseB",
+      "DepB",
+      "DepDepB"
+    ],
+    "exports": {
+      "CaseB": true
+    },
+    "shared": {},
+    "imports": {
+      "DepAB": true,
+      "$estr": true,
+      "$hxEnums": true,
+      "$hxClasses": true,
+      "lib_Lib2": true
+    }
+  },
+  {
+    "isMain": false,
+    "isLib": true,
+    "name": "lib",
+    "nodes": [
+      "lib_DepLib",
+      "lib_Lib",
+      "lib_Lib2"
+    ],
+    "exports": {
+      "lib_Lib": true,
+      "lib_Lib2": true
+    },
+    "shared": {},
+    "imports": {
+      "$hxClasses": true
+    }
+  }
+]

--- a/tool/test/expect/haxe_4_es6/node-release-test5.json
+++ b/tool/test/expect/haxe_4_es6/node-release-test5.json
@@ -1,0 +1,93 @@
+[
+  {
+    "isMain": true,
+    "isLib": false,
+    "name": "Test5",
+    "nodes": [
+      "$estr",
+      "$hxClasses",
+      "$hxEnums",
+      "DepAB",
+      "DepDepAB",
+      "DepDepMain",
+      "DepMain",
+      "Require",
+      "Test5",
+      "haxe_IMap",
+      "haxe_ds_StringMap",
+      "js_Boot",
+      "js__$Boot_HaxeError"
+    ],
+    "exports": {
+      "$hxClasses": true,
+      "DepAB": true,
+      "$estr": true,
+      "$hxEnums": true
+    },
+    "shared": {
+      "lib_Lib2": true,
+      "a_$b_C_$_$d": true,
+      "CaseA": true,
+      "CaseB": true
+    },
+    "imports": {}
+  },
+  {
+    "isMain": false,
+    "isLib": false,
+    "name": "CaseA",
+    "nodes": [
+      "CaseA"
+    ],
+    "exports": {
+      "CaseA": true
+    },
+    "shared": {},
+    "imports": {
+      "DepAB": true,
+      "lib_Lib": true,
+      "$hxClasses": true
+    }
+  },
+  {
+    "isMain": false,
+    "isLib": false,
+    "name": "CaseB",
+    "nodes": [
+      "CaseB",
+      "DepB",
+      "DepDepB"
+    ],
+    "exports": {
+      "CaseB": true
+    },
+    "shared": {},
+    "imports": {
+      "DepAB": true,
+      "$estr": true,
+      "$hxEnums": true,
+      "$hxClasses": true,
+      "lib_Lib2": true
+    }
+  },
+  {
+    "isMain": false,
+    "isLib": true,
+    "name": "lib",
+    "nodes": [
+      "a_$b_C_$_$d",
+      "lib_DepLib",
+      "lib_Lib",
+      "lib_Lib2"
+    ],
+    "exports": {
+      "lib_Lib2": true,
+      "a_$b_C_$_$d": true,
+      "lib_Lib": true
+    },
+    "shared": {},
+    "imports": {
+      "$hxClasses": true
+    }
+  }
+]

--- a/tool/test/expect/haxe_4_es6/node-release-test6.json
+++ b/tool/test/expect/haxe_4_es6/node-release-test6.json
@@ -1,0 +1,37 @@
+[
+  {
+    "isMain": true,
+    "isLib": false,
+    "name": "Test6",
+    "nodes": [
+      "$hxClasses",
+      "Reflected",
+      "Test6",
+      "Type"
+    ],
+    "exports": {
+      "$hxClasses": true
+    },
+    "shared": {
+      "CaseA": true
+    },
+    "imports": {}
+  },
+  {
+    "isMain": false,
+    "isLib": false,
+    "name": "CaseA",
+    "nodes": [
+      "CaseA",
+      "DepAB",
+      "DepDepAB"
+    ],
+    "exports": {
+      "CaseA": true
+    },
+    "shared": {},
+    "imports": {
+      "$hxClasses": true
+    }
+  }
+]

--- a/tool/test/expect/haxe_4_es6/node-release-test7.json
+++ b/tool/test/expect/haxe_4_es6/node-release-test7.json
@@ -1,0 +1,34 @@
+[
+  {
+    "isMain": true,
+    "isLib": false,
+    "name": "Test7",
+    "nodes": [
+      "$hxClasses",
+      "Test7"
+    ],
+    "exports": {
+      "$hxClasses": true
+    },
+    "shared": {
+      "CaseD": true
+    },
+    "imports": {}
+  },
+  {
+    "isMain": false,
+    "isLib": false,
+    "name": "CaseD",
+    "nodes": [
+      "CaseD",
+      "CycleD"
+    ],
+    "exports": {
+      "CaseD": true
+    },
+    "shared": {},
+    "imports": {
+      "$hxClasses": true
+    }
+  }
+]

--- a/tool/test/expect/haxe_4_es6/node-release-test8.json
+++ b/tool/test/expect/haxe_4_es6/node-release-test8.json
@@ -1,0 +1,14 @@
+[
+  {
+    "isMain": true,
+    "isLib": false,
+    "name": "Test8",
+    "nodes": [
+      "$hxClasses",
+      "Test8"
+    ],
+    "exports": {},
+    "shared": {},
+    "imports": {}
+  }
+]

--- a/tool/test/expect/haxe_4_es6/node-release-test9.json
+++ b/tool/test/expect/haxe_4_es6/node-release-test9.json
@@ -1,0 +1,33 @@
+[
+  {
+    "isMain": true,
+    "isLib": false,
+    "name": "Test9",
+    "nodes": [
+      "$hxClasses",
+      "Test9"
+    ],
+    "exports": {
+      "$hxClasses": true
+    },
+    "shared": {
+      "CaseD": true
+    },
+    "imports": {}
+  },
+  {
+    "isMain": false,
+    "isLib": false,
+    "name": "CaseD",
+    "nodes": [
+      "CaseD"
+    ],
+    "exports": {
+      "CaseD": true
+    },
+    "shared": {},
+    "imports": {
+      "$hxClasses": true
+    }
+  }
+]

--- a/tool/test/expect/haxe_4_es6/web-debug-closure-testinterop.json
+++ b/tool/test/expect/haxe_4_es6/web-debug-closure-testinterop.json
@@ -1,0 +1,69 @@
+[
+  {
+    "isMain": true,
+    "isLib": false,
+    "name": "TestInterop",
+    "nodes": [
+      "Bool",
+      "Class",
+      "Dynamic",
+      "Enum",
+      "Float",
+      "Int",
+      "Require",
+      "Std",
+      "TestInterop",
+      "haxe_IMap",
+      "haxe_Timer",
+      "haxe_ds_StringMap",
+      "js_Boot",
+      "js__$Boot_HaxeError",
+      "require"
+    ],
+    "exports": {
+      "js_Boot": true,
+      "Int": true,
+      "Float": true,
+      "Require": true,
+      "require": true
+    },
+    "shared": {
+      "CaseInterop": true
+    },
+    "imports": {}
+  },
+  {
+    "isMain": false,
+    "isLib": false,
+    "name": "CaseInterop",
+    "nodes": [
+      "CaseInterop"
+    ],
+    "exports": {
+      "CaseInterop": true
+    },
+    "shared": {
+      "a_$b_C_$_$d": true
+    },
+    "imports": {
+      "js_Boot": true,
+      "Int": true,
+      "Float": true,
+      "Require": true,
+      "require": true
+    }
+  },
+  {
+    "isMain": false,
+    "isLib": false,
+    "name": "a_$b_C_$_$d",
+    "nodes": [
+      "a_$b_C_$_$d"
+    ],
+    "exports": {
+      "a_$b_C_$_$d": true
+    },
+    "shared": {},
+    "imports": {}
+  }
+]

--- a/tool/test/expect/haxe_4_es6/web-debug-test1.json
+++ b/tool/test/expect/haxe_4_es6/web-debug-test1.json
@@ -1,0 +1,68 @@
+[
+  {
+    "isMain": true,
+    "isLib": false,
+    "name": "Test1",
+    "nodes": [
+      "$estr",
+      "$hxClasses",
+      "$hxEnums",
+      "DepAB",
+      "DepDepAB",
+      "DepDepB",
+      "Require",
+      "Std",
+      "Test1",
+      "haxe_IMap",
+      "haxe_Timer",
+      "haxe_ds_StringMap",
+      "js_Boot",
+      "js__$Boot_HaxeError",
+      "require"
+    ],
+    "exports": {
+      "DepAB": true,
+      "$hxClasses": true,
+      "DepDepB": true
+    },
+    "shared": {
+      "CaseA": true,
+      "CaseB": true
+    },
+    "imports": {}
+  },
+  {
+    "isMain": false,
+    "isLib": false,
+    "name": "CaseA",
+    "nodes": [
+      "CaseA"
+    ],
+    "exports": {
+      "CaseA": true
+    },
+    "shared": {},
+    "imports": {
+      "DepAB": true,
+      "$hxClasses": true
+    }
+  },
+  {
+    "isMain": false,
+    "isLib": false,
+    "name": "CaseB",
+    "nodes": [
+      "CaseB",
+      "DepB"
+    ],
+    "exports": {
+      "CaseB": true
+    },
+    "shared": {},
+    "imports": {
+      "DepAB": true,
+      "DepDepB": true,
+      "$hxClasses": true
+    }
+  }
+]

--- a/tool/test/expect/haxe_4_es6/web-debug-test10.json
+++ b/tool/test/expect/haxe_4_es6/web-debug-test10.json
@@ -1,0 +1,65 @@
+[
+  {
+    "isMain": true,
+    "isLib": false,
+    "name": "Test10",
+    "nodes": [
+      "$hxClasses",
+      "Require",
+      "Std",
+      "Test10",
+      "Test10",
+      "haxe_IMap",
+      "haxe_Timer",
+      "haxe_ds_StringMap",
+      "js_Boot",
+      "js__$Boot_HaxeError",
+      "require"
+    ],
+    "exports": {
+      "Test10": true,
+      "Require": true,
+      "$hxClasses": true
+    },
+    "shared": {
+      "CaseE": true
+    },
+    "imports": {}
+  },
+  {
+    "isMain": false,
+    "isLib": false,
+    "name": "CaseE",
+    "nodes": [
+      "CaseE"
+    ],
+    "exports": {
+      "CaseE": true
+    },
+    "shared": {
+      "DepE": true
+    },
+    "imports": {
+      "Test10": true,
+      "Require": true,
+      "$hxClasses": true
+    }
+  },
+  {
+    "isMain": false,
+    "isLib": false,
+    "name": "DepE",
+    "nodes": [
+      "DepE"
+    ],
+    "exports": {
+      "DepE": true
+    },
+    "shared": {},
+    "imports": {
+      "CaseE": true,
+      "Test10": true,
+      "$hxClasses": true
+    }
+  }
+]

--- a/tool/test/expect/haxe_4_es6/web-debug-test11.json
+++ b/tool/test/expect/haxe_4_es6/web-debug-test11.json
@@ -1,0 +1,43 @@
+[
+  {
+    "isMain": true,
+    "isLib": false,
+    "name": "Test11",
+    "nodes": [
+      "$hxClasses",
+      "Require",
+      "Std",
+      "Test11",
+      "haxe_IMap",
+      "haxe_Timer",
+      "haxe_ds_StringMap",
+      "js_Boot",
+      "js__$Boot_HaxeError",
+      "require"
+    ],
+    "exports": {
+      "js__$Boot_HaxeError": true,
+      "$hxClasses": true
+    },
+    "shared": {
+      "CaseF": true
+    },
+    "imports": {}
+  },
+  {
+    "isMain": false,
+    "isLib": false,
+    "name": "CaseF",
+    "nodes": [
+      "CaseF"
+    ],
+    "exports": {
+      "CaseF": true
+    },
+    "shared": {},
+    "imports": {
+      "js__$Boot_HaxeError": true,
+      "$hxClasses": true
+    }
+  }
+]

--- a/tool/test/expect/haxe_4_es6/web-debug-test12.json
+++ b/tool/test/expect/haxe_4_es6/web-debug-test12.json
@@ -1,0 +1,43 @@
+[
+  {
+    "isMain": true,
+    "isLib": false,
+    "name": "Test12",
+    "nodes": [
+      "$hxClasses",
+      "DepDepMain",
+      "DepMain",
+      "Require",
+      "Test12",
+      "haxe_IMap",
+      "haxe_ds_StringMap",
+      "require"
+    ],
+    "exports": {
+      "$hxClasses": true
+    },
+    "shared": {
+      "lib_Lib2": true,
+      "a_$b_C_$_$d": true
+    },
+    "imports": {}
+  },
+  {
+    "isMain": false,
+    "isLib": true,
+    "name": "lib",
+    "nodes": [
+      "a_$b_C_$_$d",
+      "lib_DepLib",
+      "lib_Lib2"
+    ],
+    "exports": {
+      "lib_Lib2": true,
+      "a_$b_C_$_$d": true
+    },
+    "shared": {},
+    "imports": {
+      "$hxClasses": true
+    }
+  }
+]

--- a/tool/test/expect/haxe_4_es6/web-debug-test13.json
+++ b/tool/test/expect/haxe_4_es6/web-debug-test13.json
@@ -1,0 +1,36 @@
+[
+  {
+    "isMain": true,
+    "isLib": false,
+    "name": "Test13",
+    "nodes": [
+      "Require",
+      "Std",
+      "Test13",
+      "haxe_Timer",
+      "haxe_ds_StringMap",
+      "js_Boot",
+      "js__$Boot_HaxeError",
+      "require"
+    ],
+    "exports": {},
+    "shared": {
+      "a_$b_Exposed": true
+    },
+    "imports": {}
+  },
+  {
+    "isMain": false,
+    "isLib": false,
+    "name": "a_$b_Exposed",
+    "nodes": [
+      "a_$b_Exposed",
+      "a_$b_SubExposed"
+    ],
+    "exports": {
+      "a_$b_Exposed": true
+    },
+    "shared": {},
+    "imports": {}
+  }
+]

--- a/tool/test/expect/haxe_4_es6/web-debug-test14.json
+++ b/tool/test/expect/haxe_4_es6/web-debug-test14.json
@@ -1,0 +1,36 @@
+[
+  {
+    "isMain": true,
+    "isLib": false,
+    "name": "Test14",
+    "nodes": [
+      "Require",
+      "Std",
+      "Test14",
+      "haxe_Timer",
+      "haxe_ds_StringMap",
+      "js_Boot",
+      "js__$Boot_HaxeError",
+      "require"
+    ],
+    "exports": {},
+    "shared": {
+      "a_$b_Exposed": true
+    },
+    "imports": {}
+  },
+  {
+    "isMain": false,
+    "isLib": false,
+    "name": "a_$b_Exposed",
+    "nodes": [
+      "a_$b_Exposed",
+      "a_$b_SubExposed"
+    ],
+    "exports": {
+      "a_$b_Exposed": true
+    },
+    "shared": {},
+    "imports": {}
+  }
+]

--- a/tool/test/expect/haxe_4_es6/web-debug-test2.json
+++ b/tool/test/expect/haxe_4_es6/web-debug-test2.json
@@ -1,0 +1,68 @@
+[
+  {
+    "isMain": true,
+    "isLib": false,
+    "name": "Test2",
+    "nodes": [
+      "$estr",
+      "$hxClasses",
+      "$hxEnums",
+      "DepAB",
+      "DepDepAB",
+      "DepDepB",
+      "Require",
+      "Std",
+      "Test2",
+      "haxe_IMap",
+      "haxe_Timer",
+      "haxe_ds_StringMap",
+      "js_Boot",
+      "js__$Boot_HaxeError",
+      "require"
+    ],
+    "exports": {
+      "DepAB": true,
+      "$hxClasses": true,
+      "DepDepB": true
+    },
+    "shared": {
+      "CaseA": true,
+      "CaseB": true
+    },
+    "imports": {}
+  },
+  {
+    "isMain": false,
+    "isLib": false,
+    "name": "CaseA",
+    "nodes": [
+      "CaseA"
+    ],
+    "exports": {
+      "CaseA": true
+    },
+    "shared": {},
+    "imports": {
+      "DepAB": true,
+      "$hxClasses": true
+    }
+  },
+  {
+    "isMain": false,
+    "isLib": false,
+    "name": "CaseB",
+    "nodes": [
+      "CaseB",
+      "DepB"
+    ],
+    "exports": {
+      "CaseB": true
+    },
+    "shared": {},
+    "imports": {
+      "DepAB": true,
+      "DepDepB": true,
+      "$hxClasses": true
+    }
+  }
+]

--- a/tool/test/expect/haxe_4_es6/web-debug-test3.json
+++ b/tool/test/expect/haxe_4_es6/web-debug-test3.json
@@ -1,0 +1,102 @@
+[
+  {
+    "isMain": true,
+    "isLib": false,
+    "name": "Test3",
+    "nodes": [
+      "$hxClasses",
+      "DepDepMain",
+      "DepMain",
+      "Require",
+      "Std",
+      "Test3",
+      "haxe_IMap",
+      "haxe_Timer",
+      "haxe_ds_StringMap",
+      "js_Boot",
+      "js__$Boot_HaxeError",
+      "require"
+    ],
+    "exports": {
+      "Require": true,
+      "DepMain": true,
+      "$hxClasses": true
+    },
+    "shared": {
+      "CaseC": true
+    },
+    "imports": {}
+  },
+  {
+    "isMain": false,
+    "isLib": false,
+    "name": "CaseC",
+    "nodes": [
+      "CaseC"
+    ],
+    "exports": {
+      "CaseC": true
+    },
+    "shared": {
+      "DepC": true
+    },
+    "imports": {
+      "Require": true,
+      "$hxClasses": true
+    }
+  },
+  {
+    "isMain": false,
+    "isLib": false,
+    "name": "DepC",
+    "nodes": [
+      "DepC",
+      "DepSubC"
+    ],
+    "exports": {
+      "DepC": true,
+      "DepSubC": true
+    },
+    "shared": {
+      "SubC": true,
+      "SubC2": true
+    },
+    "imports": {
+      "Require": true,
+      "DepMain": true,
+      "$hxClasses": true
+    }
+  },
+  {
+    "isMain": false,
+    "isLib": false,
+    "name": "SubC",
+    "nodes": [
+      "SubC"
+    ],
+    "exports": {
+      "SubC": true
+    },
+    "shared": {},
+    "imports": {
+      "DepSubC": true,
+      "$hxClasses": true
+    }
+  },
+  {
+    "isMain": false,
+    "isLib": false,
+    "name": "SubC2",
+    "nodes": [
+      "SubC2"
+    ],
+    "exports": {
+      "SubC2": true
+    },
+    "shared": {},
+    "imports": {
+      "DepSubC": true,
+      "$hxClasses": true
+    }
+  }
+]

--- a/tool/test/expect/haxe_4_es6/web-debug-test4.json
+++ b/tool/test/expect/haxe_4_es6/web-debug-test4.json
@@ -1,0 +1,90 @@
+[
+  {
+    "isMain": true,
+    "isLib": false,
+    "name": "Test4",
+    "nodes": [
+      "$estr",
+      "$hxClasses",
+      "$hxEnums",
+      "DepAB",
+      "DepDepAB",
+      "DepDepB",
+      "DepDepMain",
+      "DepMain",
+      "Require",
+      "Std",
+      "Test4",
+      "haxe_IMap",
+      "haxe_Timer",
+      "haxe_ds_StringMap",
+      "js_Boot",
+      "js__$Boot_HaxeError",
+      "require"
+    ],
+    "exports": {
+      "DepAB": true,
+      "$hxClasses": true,
+      "DepDepB": true
+    },
+    "shared": {
+      "CaseA": true,
+      "CaseB": true
+    },
+    "imports": {}
+  },
+  {
+    "isMain": false,
+    "isLib": false,
+    "name": "CaseA",
+    "nodes": [
+      "CaseA"
+    ],
+    "exports": {
+      "CaseA": true
+    },
+    "shared": {},
+    "imports": {
+      "DepAB": true,
+      "lib_Lib": true,
+      "$hxClasses": true
+    }
+  },
+  {
+    "isMain": false,
+    "isLib": false,
+    "name": "CaseB",
+    "nodes": [
+      "CaseB",
+      "DepB"
+    ],
+    "exports": {
+      "CaseB": true
+    },
+    "shared": {},
+    "imports": {
+      "DepAB": true,
+      "DepDepB": true,
+      "$hxClasses": true,
+      "lib_Lib2": true
+    }
+  },
+  {
+    "isMain": false,
+    "isLib": true,
+    "name": "lib",
+    "nodes": [
+      "lib_DepLib",
+      "lib_Lib",
+      "lib_Lib2"
+    ],
+    "exports": {
+      "lib_Lib": true,
+      "lib_Lib2": true
+    },
+    "shared": {},
+    "imports": {
+      "$hxClasses": true
+    }
+  }
+]

--- a/tool/test/expect/haxe_4_es6/web-debug-test5.json
+++ b/tool/test/expect/haxe_4_es6/web-debug-test5.json
@@ -1,0 +1,94 @@
+[
+  {
+    "isMain": true,
+    "isLib": false,
+    "name": "Test5",
+    "nodes": [
+      "$estr",
+      "$hxClasses",
+      "$hxEnums",
+      "DepAB",
+      "DepDepAB",
+      "DepDepB",
+      "DepDepMain",
+      "DepMain",
+      "Require",
+      "Std",
+      "Test5",
+      "haxe_IMap",
+      "haxe_Timer",
+      "haxe_ds_StringMap",
+      "js_Boot",
+      "js__$Boot_HaxeError",
+      "require"
+    ],
+    "exports": {
+      "$hxClasses": true,
+      "DepAB": true,
+      "DepDepB": true
+    },
+    "shared": {
+      "lib_Lib2": true,
+      "a_$b_C_$_$d": true,
+      "CaseA": true,
+      "CaseB": true
+    },
+    "imports": {}
+  },
+  {
+    "isMain": false,
+    "isLib": false,
+    "name": "CaseA",
+    "nodes": [
+      "CaseA"
+    ],
+    "exports": {
+      "CaseA": true
+    },
+    "shared": {},
+    "imports": {
+      "DepAB": true,
+      "lib_Lib": true,
+      "$hxClasses": true
+    }
+  },
+  {
+    "isMain": false,
+    "isLib": false,
+    "name": "CaseB",
+    "nodes": [
+      "CaseB",
+      "DepB"
+    ],
+    "exports": {
+      "CaseB": true
+    },
+    "shared": {},
+    "imports": {
+      "DepAB": true,
+      "DepDepB": true,
+      "$hxClasses": true,
+      "lib_Lib2": true
+    }
+  },
+  {
+    "isMain": false,
+    "isLib": true,
+    "name": "lib",
+    "nodes": [
+      "a_$b_C_$_$d",
+      "lib_DepLib",
+      "lib_Lib",
+      "lib_Lib2"
+    ],
+    "exports": {
+      "lib_Lib2": true,
+      "a_$b_C_$_$d": true,
+      "lib_Lib": true
+    },
+    "shared": {},
+    "imports": {
+      "$hxClasses": true
+    }
+  }
+]

--- a/tool/test/expect/haxe_4_es6/web-debug-test6.json
+++ b/tool/test/expect/haxe_4_es6/web-debug-test6.json
@@ -1,0 +1,45 @@
+[
+  {
+    "isMain": true,
+    "isLib": false,
+    "name": "Test6",
+    "nodes": [
+      "$hxClasses",
+      "Reflected",
+      "Require",
+      "Std",
+      "Test6",
+      "Type",
+      "haxe_IMap",
+      "haxe_Timer",
+      "haxe_ds_StringMap",
+      "js_Boot",
+      "js__$Boot_HaxeError",
+      "require"
+    ],
+    "exports": {
+      "$hxClasses": true
+    },
+    "shared": {
+      "CaseA": true
+    },
+    "imports": {}
+  },
+  {
+    "isMain": false,
+    "isLib": false,
+    "name": "CaseA",
+    "nodes": [
+      "CaseA",
+      "DepAB",
+      "DepDepAB"
+    ],
+    "exports": {
+      "CaseA": true
+    },
+    "shared": {},
+    "imports": {
+      "$hxClasses": true
+    }
+  }
+]

--- a/tool/test/expect/haxe_4_es6/web-debug-test7.json
+++ b/tool/test/expect/haxe_4_es6/web-debug-test7.json
@@ -1,0 +1,42 @@
+[
+  {
+    "isMain": true,
+    "isLib": false,
+    "name": "Test7",
+    "nodes": [
+      "$hxClasses",
+      "Require",
+      "Std",
+      "Test7",
+      "haxe_IMap",
+      "haxe_Timer",
+      "haxe_ds_StringMap",
+      "js_Boot",
+      "js__$Boot_HaxeError",
+      "require"
+    ],
+    "exports": {
+      "$hxClasses": true
+    },
+    "shared": {
+      "CaseD": true
+    },
+    "imports": {}
+  },
+  {
+    "isMain": false,
+    "isLib": false,
+    "name": "CaseD",
+    "nodes": [
+      "CaseD",
+      "CycleD"
+    ],
+    "exports": {
+      "CaseD": true
+    },
+    "shared": {},
+    "imports": {
+      "$hxClasses": true
+    }
+  }
+]

--- a/tool/test/expect/haxe_4_es6/web-debug-test8.json
+++ b/tool/test/expect/haxe_4_es6/web-debug-test8.json
@@ -1,0 +1,15 @@
+[
+  {
+    "isMain": true,
+    "isLib": false,
+    "name": "Test8",
+    "nodes": [
+      "$hxClasses",
+      "Test8",
+      "require"
+    ],
+    "exports": {},
+    "shared": {},
+    "imports": {}
+  }
+]

--- a/tool/test/expect/haxe_4_es6/web-debug-test9.json
+++ b/tool/test/expect/haxe_4_es6/web-debug-test9.json
@@ -1,0 +1,41 @@
+[
+  {
+    "isMain": true,
+    "isLib": false,
+    "name": "Test9",
+    "nodes": [
+      "$hxClasses",
+      "Require",
+      "Std",
+      "Test9",
+      "haxe_IMap",
+      "haxe_Timer",
+      "haxe_ds_StringMap",
+      "js_Boot",
+      "js__$Boot_HaxeError",
+      "require"
+    ],
+    "exports": {
+      "$hxClasses": true
+    },
+    "shared": {
+      "CaseD": true
+    },
+    "imports": {}
+  },
+  {
+    "isMain": false,
+    "isLib": false,
+    "name": "CaseD",
+    "nodes": [
+      "CaseD"
+    ],
+    "exports": {
+      "CaseD": true
+    },
+    "shared": {},
+    "imports": {
+      "$hxClasses": true
+    }
+  }
+]

--- a/tool/test/expect/haxe_4_es6/web-debug-testinterop.json
+++ b/tool/test/expect/haxe_4_es6/web-debug-testinterop.json
@@ -1,0 +1,69 @@
+[
+  {
+    "isMain": true,
+    "isLib": false,
+    "name": "TestInterop",
+    "nodes": [
+      "Bool",
+      "Class",
+      "Dynamic",
+      "Enum",
+      "Float",
+      "Int",
+      "Require",
+      "Std",
+      "TestInterop",
+      "haxe_IMap",
+      "haxe_Timer",
+      "haxe_ds_StringMap",
+      "js_Boot",
+      "js__$Boot_HaxeError",
+      "require"
+    ],
+    "exports": {
+      "js_Boot": true,
+      "Int": true,
+      "Float": true,
+      "Require": true,
+      "require": true
+    },
+    "shared": {
+      "CaseInterop": true
+    },
+    "imports": {}
+  },
+  {
+    "isMain": false,
+    "isLib": false,
+    "name": "CaseInterop",
+    "nodes": [
+      "CaseInterop"
+    ],
+    "exports": {
+      "CaseInterop": true
+    },
+    "shared": {
+      "a_$b_C_$_$d": true
+    },
+    "imports": {
+      "js_Boot": true,
+      "Int": true,
+      "Float": true,
+      "Require": true,
+      "require": true
+    }
+  },
+  {
+    "isMain": false,
+    "isLib": false,
+    "name": "a_$b_C_$_$d",
+    "nodes": [
+      "a_$b_C_$_$d"
+    ],
+    "exports": {
+      "a_$b_C_$_$d": true
+    },
+    "shared": {},
+    "imports": {}
+  }
+]

--- a/tool/test/expect/haxe_4_es6/web-debug-uglify-testinterop.json
+++ b/tool/test/expect/haxe_4_es6/web-debug-uglify-testinterop.json
@@ -1,0 +1,69 @@
+[
+  {
+    "isMain": true,
+    "isLib": false,
+    "name": "TestInterop",
+    "nodes": [
+      "Bool",
+      "Class",
+      "Dynamic",
+      "Enum",
+      "Float",
+      "Int",
+      "Require",
+      "Std",
+      "TestInterop",
+      "haxe_IMap",
+      "haxe_Timer",
+      "haxe_ds_StringMap",
+      "js_Boot",
+      "js__$Boot_HaxeError",
+      "require"
+    ],
+    "exports": {
+      "js_Boot": true,
+      "Int": true,
+      "Float": true,
+      "Require": true,
+      "require": true
+    },
+    "shared": {
+      "CaseInterop": true
+    },
+    "imports": {}
+  },
+  {
+    "isMain": false,
+    "isLib": false,
+    "name": "CaseInterop",
+    "nodes": [
+      "CaseInterop"
+    ],
+    "exports": {
+      "CaseInterop": true
+    },
+    "shared": {
+      "a_$b_C_$_$d": true
+    },
+    "imports": {
+      "js_Boot": true,
+      "Int": true,
+      "Float": true,
+      "Require": true,
+      "require": true
+    }
+  },
+  {
+    "isMain": false,
+    "isLib": false,
+    "name": "a_$b_C_$_$d",
+    "nodes": [
+      "a_$b_C_$_$d"
+    ],
+    "exports": {
+      "a_$b_C_$_$d": true
+    },
+    "shared": {},
+    "imports": {}
+  }
+]

--- a/tool/test/expect/haxe_4_es6/web-release-closure-testinterop.json
+++ b/tool/test/expect/haxe_4_es6/web-release-closure-testinterop.json
@@ -1,0 +1,68 @@
+[
+  {
+    "isMain": true,
+    "isLib": false,
+    "name": "TestInterop",
+    "nodes": [
+      "Bool",
+      "Class",
+      "Dynamic",
+      "Enum",
+      "Float",
+      "Int",
+      "Require",
+      "Std",
+      "TestInterop",
+      "haxe_IMap",
+      "haxe_ds_StringMap",
+      "js_Boot",
+      "js__$Boot_HaxeError",
+      "require"
+    ],
+    "exports": {
+      "js_Boot": true,
+      "Int": true,
+      "Float": true,
+      "Require": true,
+      "require": true
+    },
+    "shared": {
+      "CaseInterop": true
+    },
+    "imports": {}
+  },
+  {
+    "isMain": false,
+    "isLib": false,
+    "name": "CaseInterop",
+    "nodes": [
+      "CaseInterop"
+    ],
+    "exports": {
+      "CaseInterop": true
+    },
+    "shared": {
+      "a_$b_C_$_$d": true
+    },
+    "imports": {
+      "js_Boot": true,
+      "Int": true,
+      "Float": true,
+      "Require": true,
+      "require": true
+    }
+  },
+  {
+    "isMain": false,
+    "isLib": false,
+    "name": "a_$b_C_$_$d",
+    "nodes": [
+      "a_$b_C_$_$d"
+    ],
+    "exports": {
+      "a_$b_C_$_$d": true
+    },
+    "shared": {},
+    "imports": {}
+  }
+]

--- a/tool/test/expect/haxe_4_es6/web-release-test1.json
+++ b/tool/test/expect/haxe_4_es6/web-release-test1.json
@@ -1,0 +1,68 @@
+[
+  {
+    "isMain": true,
+    "isLib": false,
+    "name": "Test1",
+    "nodes": [
+      "$estr",
+      "$hxClasses",
+      "$hxEnums",
+      "DepAB",
+      "DepDepAB",
+      "Require",
+      "Test1",
+      "haxe_IMap",
+      "haxe_ds_StringMap",
+      "js_Boot",
+      "js__$Boot_HaxeError",
+      "require"
+    ],
+    "exports": {
+      "DepAB": true,
+      "$hxClasses": true,
+      "$estr": true,
+      "$hxEnums": true
+    },
+    "shared": {
+      "CaseA": true,
+      "CaseB": true
+    },
+    "imports": {}
+  },
+  {
+    "isMain": false,
+    "isLib": false,
+    "name": "CaseA",
+    "nodes": [
+      "CaseA"
+    ],
+    "exports": {
+      "CaseA": true
+    },
+    "shared": {},
+    "imports": {
+      "DepAB": true,
+      "$hxClasses": true
+    }
+  },
+  {
+    "isMain": false,
+    "isLib": false,
+    "name": "CaseB",
+    "nodes": [
+      "CaseB",
+      "DepB",
+      "DepDepB"
+    ],
+    "exports": {
+      "CaseB": true
+    },
+    "shared": {},
+    "imports": {
+      "DepAB": true,
+      "$estr": true,
+      "$hxEnums": true,
+      "$hxClasses": true
+    }
+  }
+]

--- a/tool/test/expect/haxe_4_es6/web-release-test10.json
+++ b/tool/test/expect/haxe_4_es6/web-release-test10.json
@@ -1,0 +1,61 @@
+[
+  {
+    "isMain": true,
+    "isLib": false,
+    "name": "Test10",
+    "nodes": [
+      "$hxClasses",
+      "Require",
+      "Test10",
+      "Test10",
+      "haxe_IMap",
+      "haxe_ds_StringMap",
+      "require"
+    ],
+    "exports": {
+      "Test10": true,
+      "Require": true,
+      "$hxClasses": true
+    },
+    "shared": {
+      "CaseE": true
+    },
+    "imports": {}
+  },
+  {
+    "isMain": false,
+    "isLib": false,
+    "name": "CaseE",
+    "nodes": [
+      "CaseE"
+    ],
+    "exports": {
+      "CaseE": true
+    },
+    "shared": {
+      "DepE": true
+    },
+    "imports": {
+      "Test10": true,
+      "Require": true,
+      "$hxClasses": true
+    }
+  },
+  {
+    "isMain": false,
+    "isLib": false,
+    "name": "DepE",
+    "nodes": [
+      "DepE"
+    ],
+    "exports": {
+      "DepE": true
+    },
+    "shared": {},
+    "imports": {
+      "CaseE": true,
+      "Test10": true,
+      "$hxClasses": true
+    }
+  }
+]

--- a/tool/test/expect/haxe_4_es6/web-release-test11.json
+++ b/tool/test/expect/haxe_4_es6/web-release-test11.json
@@ -1,0 +1,38 @@
+[
+  {
+    "isMain": true,
+    "isLib": false,
+    "name": "Test11",
+    "nodes": [
+      "$hxClasses",
+      "Require",
+      "Test11",
+      "haxe_IMap",
+      "haxe_ds_StringMap",
+      "require"
+    ],
+    "exports": {
+      "$hxClasses": true
+    },
+    "shared": {
+      "CaseF": true
+    },
+    "imports": {}
+  },
+  {
+    "isMain": false,
+    "isLib": false,
+    "name": "CaseF",
+    "nodes": [
+      "CaseF",
+      "js__$Boot_HaxeError"
+    ],
+    "exports": {
+      "CaseF": true
+    },
+    "shared": {},
+    "imports": {
+      "$hxClasses": true
+    }
+  }
+]

--- a/tool/test/expect/haxe_4_es6/web-release-test12.json
+++ b/tool/test/expect/haxe_4_es6/web-release-test12.json
@@ -1,0 +1,43 @@
+[
+  {
+    "isMain": true,
+    "isLib": false,
+    "name": "Test12",
+    "nodes": [
+      "$hxClasses",
+      "DepDepMain",
+      "DepMain",
+      "Require",
+      "Test12",
+      "haxe_IMap",
+      "haxe_ds_StringMap",
+      "require"
+    ],
+    "exports": {
+      "$hxClasses": true
+    },
+    "shared": {
+      "lib_Lib2": true,
+      "a_$b_C_$_$d": true
+    },
+    "imports": {}
+  },
+  {
+    "isMain": false,
+    "isLib": true,
+    "name": "lib",
+    "nodes": [
+      "a_$b_C_$_$d",
+      "lib_DepLib",
+      "lib_Lib2"
+    ],
+    "exports": {
+      "lib_Lib2": true,
+      "a_$b_C_$_$d": true
+    },
+    "shared": {},
+    "imports": {
+      "$hxClasses": true
+    }
+  }
+]

--- a/tool/test/expect/haxe_4_es6/web-release-test13.json
+++ b/tool/test/expect/haxe_4_es6/web-release-test13.json
@@ -6,13 +6,9 @@
     "nodes": [
       "$hxClasses",
       "Require",
-      "Std",
       "Test13",
       "haxe_IMap",
-      "haxe_Timer",
       "haxe_ds_StringMap",
-      "js_Boot",
-      "js__$Boot_HaxeError",
       "require"
     ],
     "exports": {

--- a/tool/test/expect/haxe_4_es6/web-release-test14.json
+++ b/tool/test/expect/haxe_4_es6/web-release-test14.json
@@ -2,22 +2,14 @@
   {
     "isMain": true,
     "isLib": false,
-    "name": "Test13",
+    "name": "Test14",
     "nodes": [
-      "$hxClasses",
       "Require",
-      "Std",
-      "Test13",
-      "haxe_IMap",
-      "haxe_Timer",
+      "Test14",
       "haxe_ds_StringMap",
-      "js_Boot",
-      "js__$Boot_HaxeError",
       "require"
     ],
-    "exports": {
-      "$hxClasses": true
-    },
+    "exports": {},
     "shared": {
       "a_$b_Exposed": true
     },
@@ -35,8 +27,6 @@
       "a_$b_Exposed": true
     },
     "shared": {},
-    "imports": {
-      "$hxClasses": true
-    }
+    "imports": {}
   }
 ]

--- a/tool/test/expect/haxe_4_es6/web-release-test2.json
+++ b/tool/test/expect/haxe_4_es6/web-release-test2.json
@@ -1,0 +1,68 @@
+[
+  {
+    "isMain": true,
+    "isLib": false,
+    "name": "Test2",
+    "nodes": [
+      "$estr",
+      "$hxClasses",
+      "$hxEnums",
+      "DepAB",
+      "DepDepAB",
+      "Require",
+      "Test2",
+      "haxe_IMap",
+      "haxe_ds_StringMap",
+      "js_Boot",
+      "js__$Boot_HaxeError",
+      "require"
+    ],
+    "exports": {
+      "DepAB": true,
+      "$hxClasses": true,
+      "$estr": true,
+      "$hxEnums": true
+    },
+    "shared": {
+      "CaseA": true,
+      "CaseB": true
+    },
+    "imports": {}
+  },
+  {
+    "isMain": false,
+    "isLib": false,
+    "name": "CaseA",
+    "nodes": [
+      "CaseA"
+    ],
+    "exports": {
+      "CaseA": true
+    },
+    "shared": {},
+    "imports": {
+      "DepAB": true,
+      "$hxClasses": true
+    }
+  },
+  {
+    "isMain": false,
+    "isLib": false,
+    "name": "CaseB",
+    "nodes": [
+      "CaseB",
+      "DepB",
+      "DepDepB"
+    ],
+    "exports": {
+      "CaseB": true
+    },
+    "shared": {},
+    "imports": {
+      "DepAB": true,
+      "$estr": true,
+      "$hxEnums": true,
+      "$hxClasses": true
+    }
+  }
+]

--- a/tool/test/expect/haxe_4_es6/web-release-test3.json
+++ b/tool/test/expect/haxe_4_es6/web-release-test3.json
@@ -1,0 +1,98 @@
+[
+  {
+    "isMain": true,
+    "isLib": false,
+    "name": "Test3",
+    "nodes": [
+      "$hxClasses",
+      "DepDepMain",
+      "DepMain",
+      "Require",
+      "Test3",
+      "haxe_IMap",
+      "haxe_ds_StringMap",
+      "require"
+    ],
+    "exports": {
+      "Require": true,
+      "DepMain": true,
+      "$hxClasses": true
+    },
+    "shared": {
+      "CaseC": true
+    },
+    "imports": {}
+  },
+  {
+    "isMain": false,
+    "isLib": false,
+    "name": "CaseC",
+    "nodes": [
+      "CaseC"
+    ],
+    "exports": {
+      "CaseC": true
+    },
+    "shared": {
+      "DepC": true
+    },
+    "imports": {
+      "Require": true,
+      "$hxClasses": true
+    }
+  },
+  {
+    "isMain": false,
+    "isLib": false,
+    "name": "DepC",
+    "nodes": [
+      "DepC",
+      "DepSubC"
+    ],
+    "exports": {
+      "DepC": true,
+      "DepSubC": true
+    },
+    "shared": {
+      "SubC": true,
+      "SubC2": true
+    },
+    "imports": {
+      "Require": true,
+      "DepMain": true,
+      "$hxClasses": true
+    }
+  },
+  {
+    "isMain": false,
+    "isLib": false,
+    "name": "SubC",
+    "nodes": [
+      "SubC"
+    ],
+    "exports": {
+      "SubC": true
+    },
+    "shared": {},
+    "imports": {
+      "DepSubC": true,
+      "$hxClasses": true
+    }
+  },
+  {
+    "isMain": false,
+    "isLib": false,
+    "name": "SubC2",
+    "nodes": [
+      "SubC2"
+    ],
+    "exports": {
+      "SubC2": true
+    },
+    "shared": {},
+    "imports": {
+      "DepSubC": true,
+      "$hxClasses": true
+    }
+  }
+]

--- a/tool/test/expect/haxe_4_es6/web-release-test4.json
+++ b/tool/test/expect/haxe_4_es6/web-release-test4.json
@@ -1,0 +1,90 @@
+[
+  {
+    "isMain": true,
+    "isLib": false,
+    "name": "Test4",
+    "nodes": [
+      "$estr",
+      "$hxClasses",
+      "$hxEnums",
+      "DepAB",
+      "DepDepAB",
+      "DepDepMain",
+      "DepMain",
+      "Require",
+      "Test4",
+      "haxe_IMap",
+      "haxe_ds_StringMap",
+      "js_Boot",
+      "js__$Boot_HaxeError",
+      "require"
+    ],
+    "exports": {
+      "DepAB": true,
+      "$hxClasses": true,
+      "$estr": true,
+      "$hxEnums": true
+    },
+    "shared": {
+      "CaseA": true,
+      "CaseB": true
+    },
+    "imports": {}
+  },
+  {
+    "isMain": false,
+    "isLib": false,
+    "name": "CaseA",
+    "nodes": [
+      "CaseA"
+    ],
+    "exports": {
+      "CaseA": true
+    },
+    "shared": {},
+    "imports": {
+      "DepAB": true,
+      "lib_Lib": true,
+      "$hxClasses": true
+    }
+  },
+  {
+    "isMain": false,
+    "isLib": false,
+    "name": "CaseB",
+    "nodes": [
+      "CaseB",
+      "DepB",
+      "DepDepB"
+    ],
+    "exports": {
+      "CaseB": true
+    },
+    "shared": {},
+    "imports": {
+      "DepAB": true,
+      "$estr": true,
+      "$hxEnums": true,
+      "$hxClasses": true,
+      "lib_Lib2": true
+    }
+  },
+  {
+    "isMain": false,
+    "isLib": true,
+    "name": "lib",
+    "nodes": [
+      "lib_DepLib",
+      "lib_Lib",
+      "lib_Lib2"
+    ],
+    "exports": {
+      "lib_Lib": true,
+      "lib_Lib2": true
+    },
+    "shared": {},
+    "imports": {
+      "$hxClasses": true
+    }
+  }
+]

--- a/tool/test/expect/haxe_4_es6/web-release-test5.json
+++ b/tool/test/expect/haxe_4_es6/web-release-test5.json
@@ -1,0 +1,94 @@
+[
+  {
+    "isMain": true,
+    "isLib": false,
+    "name": "Test5",
+    "nodes": [
+      "$estr",
+      "$hxClasses",
+      "$hxEnums",
+      "DepAB",
+      "DepDepAB",
+      "DepDepMain",
+      "DepMain",
+      "Require",
+      "Test5",
+      "haxe_IMap",
+      "haxe_ds_StringMap",
+      "js_Boot",
+      "js__$Boot_HaxeError",
+      "require"
+    ],
+    "exports": {
+      "$hxClasses": true,
+      "DepAB": true,
+      "$estr": true,
+      "$hxEnums": true
+    },
+    "shared": {
+      "lib_Lib2": true,
+      "a_$b_C_$_$d": true,
+      "CaseA": true,
+      "CaseB": true
+    },
+    "imports": {}
+  },
+  {
+    "isMain": false,
+    "isLib": false,
+    "name": "CaseA",
+    "nodes": [
+      "CaseA"
+    ],
+    "exports": {
+      "CaseA": true
+    },
+    "shared": {},
+    "imports": {
+      "DepAB": true,
+      "lib_Lib": true,
+      "$hxClasses": true
+    }
+  },
+  {
+    "isMain": false,
+    "isLib": false,
+    "name": "CaseB",
+    "nodes": [
+      "CaseB",
+      "DepB",
+      "DepDepB"
+    ],
+    "exports": {
+      "CaseB": true
+    },
+    "shared": {},
+    "imports": {
+      "DepAB": true,
+      "$estr": true,
+      "$hxEnums": true,
+      "$hxClasses": true,
+      "lib_Lib2": true
+    }
+  },
+  {
+    "isMain": false,
+    "isLib": true,
+    "name": "lib",
+    "nodes": [
+      "a_$b_C_$_$d",
+      "lib_DepLib",
+      "lib_Lib",
+      "lib_Lib2"
+    ],
+    "exports": {
+      "lib_Lib2": true,
+      "a_$b_C_$_$d": true,
+      "lib_Lib": true
+    },
+    "shared": {},
+    "imports": {
+      "$hxClasses": true
+    }
+  }
+]

--- a/tool/test/expect/haxe_4_es6/web-release-test6.json
+++ b/tool/test/expect/haxe_4_es6/web-release-test6.json
@@ -1,0 +1,41 @@
+[
+  {
+    "isMain": true,
+    "isLib": false,
+    "name": "Test6",
+    "nodes": [
+      "$hxClasses",
+      "Reflected",
+      "Require",
+      "Test6",
+      "Type",
+      "haxe_IMap",
+      "haxe_ds_StringMap",
+      "require"
+    ],
+    "exports": {
+      "$hxClasses": true
+    },
+    "shared": {
+      "CaseA": true
+    },
+    "imports": {}
+  },
+  {
+    "isMain": false,
+    "isLib": false,
+    "name": "CaseA",
+    "nodes": [
+      "CaseA",
+      "DepAB",
+      "DepDepAB"
+    ],
+    "exports": {
+      "CaseA": true
+    },
+    "shared": {},
+    "imports": {
+      "$hxClasses": true
+    }
+  }
+]

--- a/tool/test/expect/haxe_4_es6/web-release-test7.json
+++ b/tool/test/expect/haxe_4_es6/web-release-test7.json
@@ -1,0 +1,38 @@
+[
+  {
+    "isMain": true,
+    "isLib": false,
+    "name": "Test7",
+    "nodes": [
+      "$hxClasses",
+      "Require",
+      "Test7",
+      "haxe_IMap",
+      "haxe_ds_StringMap",
+      "require"
+    ],
+    "exports": {
+      "$hxClasses": true
+    },
+    "shared": {
+      "CaseD": true
+    },
+    "imports": {}
+  },
+  {
+    "isMain": false,
+    "isLib": false,
+    "name": "CaseD",
+    "nodes": [
+      "CaseD",
+      "CycleD"
+    ],
+    "exports": {
+      "CaseD": true
+    },
+    "shared": {},
+    "imports": {
+      "$hxClasses": true
+    }
+  }
+]

--- a/tool/test/expect/haxe_4_es6/web-release-test8.json
+++ b/tool/test/expect/haxe_4_es6/web-release-test8.json
@@ -1,0 +1,15 @@
+[
+  {
+    "isMain": true,
+    "isLib": false,
+    "name": "Test8",
+    "nodes": [
+      "$hxClasses",
+      "Test8",
+      "require"
+    ],
+    "exports": {},
+    "shared": {},
+    "imports": {}
+  }
+]

--- a/tool/test/expect/haxe_4_es6/web-release-test9.json
+++ b/tool/test/expect/haxe_4_es6/web-release-test9.json
@@ -1,0 +1,37 @@
+[
+  {
+    "isMain": true,
+    "isLib": false,
+    "name": "Test9",
+    "nodes": [
+      "$hxClasses",
+      "Require",
+      "Test9",
+      "haxe_IMap",
+      "haxe_ds_StringMap",
+      "require"
+    ],
+    "exports": {
+      "$hxClasses": true
+    },
+    "shared": {
+      "CaseD": true
+    },
+    "imports": {}
+  },
+  {
+    "isMain": false,
+    "isLib": false,
+    "name": "CaseD",
+    "nodes": [
+      "CaseD"
+    ],
+    "exports": {
+      "CaseD": true
+    },
+    "shared": {},
+    "imports": {
+      "$hxClasses": true
+    }
+  }
+]

--- a/tool/test/expect/haxe_4_es6/web-release-testinterop.json
+++ b/tool/test/expect/haxe_4_es6/web-release-testinterop.json
@@ -1,0 +1,68 @@
+[
+  {
+    "isMain": true,
+    "isLib": false,
+    "name": "TestInterop",
+    "nodes": [
+      "Bool",
+      "Class",
+      "Dynamic",
+      "Enum",
+      "Float",
+      "Int",
+      "Require",
+      "Std",
+      "TestInterop",
+      "haxe_IMap",
+      "haxe_ds_StringMap",
+      "js_Boot",
+      "js__$Boot_HaxeError",
+      "require"
+    ],
+    "exports": {
+      "js_Boot": true,
+      "Int": true,
+      "Float": true,
+      "Require": true,
+      "require": true
+    },
+    "shared": {
+      "CaseInterop": true
+    },
+    "imports": {}
+  },
+  {
+    "isMain": false,
+    "isLib": false,
+    "name": "CaseInterop",
+    "nodes": [
+      "CaseInterop"
+    ],
+    "exports": {
+      "CaseInterop": true
+    },
+    "shared": {
+      "a_$b_C_$_$d": true
+    },
+    "imports": {
+      "js_Boot": true,
+      "Int": true,
+      "Float": true,
+      "Require": true,
+      "require": true
+    }
+  },
+  {
+    "isMain": false,
+    "isLib": false,
+    "name": "a_$b_C_$_$d",
+    "nodes": [
+      "a_$b_C_$_$d"
+    ],
+    "exports": {
+      "a_$b_C_$_$d": true
+    },
+    "shared": {},
+    "imports": {}
+  }
+]

--- a/tool/test/expect/haxe_4_es6/web-release-uglify-testinterop.json
+++ b/tool/test/expect/haxe_4_es6/web-release-uglify-testinterop.json
@@ -1,0 +1,68 @@
+[
+  {
+    "isMain": true,
+    "isLib": false,
+    "name": "TestInterop",
+    "nodes": [
+      "Bool",
+      "Class",
+      "Dynamic",
+      "Enum",
+      "Float",
+      "Int",
+      "Require",
+      "Std",
+      "TestInterop",
+      "haxe_IMap",
+      "haxe_ds_StringMap",
+      "js_Boot",
+      "js__$Boot_HaxeError",
+      "require"
+    ],
+    "exports": {
+      "js_Boot": true,
+      "Int": true,
+      "Float": true,
+      "Require": true,
+      "require": true
+    },
+    "shared": {
+      "CaseInterop": true
+    },
+    "imports": {}
+  },
+  {
+    "isMain": false,
+    "isLib": false,
+    "name": "CaseInterop",
+    "nodes": [
+      "CaseInterop"
+    ],
+    "exports": {
+      "CaseInterop": true
+    },
+    "shared": {
+      "a_$b_C_$_$d": true
+    },
+    "imports": {
+      "js_Boot": true,
+      "Int": true,
+      "Float": true,
+      "Require": true,
+      "require": true
+    }
+  },
+  {
+    "isMain": false,
+    "isLib": false,
+    "name": "a_$b_C_$_$d",
+    "nodes": [
+      "a_$b_C_$_$d"
+    ],
+    "exports": {
+      "a_$b_C_$_$d": true
+    },
+    "shared": {},
+    "imports": {}
+  }
+]

--- a/tool/test/src/Test13.hx
+++ b/tool/test/src/Test13.hx
@@ -1,0 +1,12 @@
+// Test13 -> a_b.Exposed
+// Haxe expose edge cases
+import a_b.Exposed;
+
+class Test13 {
+	static function main() {
+		trace('Suite ' + Type.getClassName(Type.resolveClass('Test13')));
+		Bundle.load(Exposed).then(function(_) {
+			new Exposed().t();
+		});
+	}
+}

--- a/tool/test/src/Test14.hx
+++ b/tool/test/src/Test14.hx
@@ -1,0 +1,12 @@
+// Test14 -> a_b.Exposed
+// Haxe expose edge cases (no Reflection)
+import a_b.Exposed;
+
+class Test14 {
+	static function main() {
+		trace('Suite Test14');
+		Bundle.load(Exposed).then(function(_) {
+			new Exposed().t();
+		});
+	}
+}

--- a/tool/test/src/a_b/Exposed.hx
+++ b/tool/test/src/a_b/Exposed.hx
@@ -1,0 +1,18 @@
+package a_b;
+
+@:expose
+class Exposed {
+    public function new() {}
+    @:expose
+    public function t() {
+        trace('exposed');
+        new SubExposed();
+    }
+}
+
+@:expose
+class SubExposed {
+    public function new() {
+        trace('subexposed');
+    }
+}

--- a/tool/test/test-suite.js
+++ b/tool/test/test-suite.js
@@ -6,7 +6,7 @@ const t0 = new Date().getTime();
 
 try { fs.mkdirSync('tool/test/bin'); } catch (_) { }
 
-const testClasses = ['Test1', 'Test2', 'Test3', 'Test4', 'Test5', 'Test6', 'Test7', 'Test8', 'Test9', 'Test10', 'Test11', 'Test12'];
+const testClasses = ['Test1', 'Test2', 'Test3', 'Test4', 'Test5', 'Test6', 'Test7', 'Test8', 'Test9', 'Test10', 'Test11', 'Test12', 'Test13', 'Test14'];
 const useLib = { Test4:true, Test5:true, Test12:true };
 
 const { only, es6 } = getOnly();

--- a/tool/test/test-suite.js
+++ b/tool/test/test-suite.js
@@ -204,6 +204,10 @@ function detectHaxe(callback) {
 				console.log('FATAL: Haxe version unsupported');
 				process.exit(-2);
 			}
+			if (v === 3 && es6) {
+				console.log('ES6 mode not supported by Haxe 3 - ignoring');
+				process.exit(0);
+			}
 			haxeVersion = `${v}${es6 ? '_es6' : ''}`;
 			try { fs.mkdirSync(`tool/test/expect/haxe_${haxeVersion}`); } catch (_) { }
 			callback();


### PR DESCRIPTION
Implement #92 , support of `-D js-es=6`, which means generating modern ES6 code with `class` keyword and all.

To try it:
- checkout the repo
- run `npm link` at the root of haxe-modular to prepare a symlink of the repo
- run `npm link haxe-modular` in your project repo to symlink to this repo