### PR TITLE
Generate bridge marker in a way that analyzer won't remove it.

### DIFF
--- a/src/Bundle.hx
+++ b/src/Bundle.hx
@@ -75,7 +75,7 @@ class Bundle
 					.map(formatMatch)
 					.join(',');
 				var module = '$libName=$pattern';
-				var bridge = '${libName}__BRIDGE__';
+				var bridge = '"${libName}__BRIDGE__"';
 				Split.register(module);
 
 				#if modular_stub
@@ -85,7 +85,7 @@ class Bundle
 				return macro {
 					@:keep Require.module($v{libName})
 						.then(function(id:String) {
-							var _ = $v{bridge};
+							untyped __js__($v{bridge});
 							return id;
 						});
 				}


### PR DESCRIPTION
The current version generates something like `var _ = "...__BRIDGE__";`, which for the analyzer is an unused variable initialized to a constant, so it throws it out. Since there's no use for the var anyway, I chose to generate it as inline JavaScript, as the compiler will never touch that.