### PR TITLE
Named bundles

### DIFF
--- a/doc/library-usage.md
+++ b/doc/library-usage.md
@@ -103,9 +103,10 @@ file, `MyAppView.js`, containing the code and dependencies of `MyAppView`.
 
 ### Bundle API
 
-`Bundle.load(module:Class):Promise<String>`
+`Bundle.load(module:Class, ?bundleName:String):Promise<String>`
 
 - `module`: the entry point class reference,
+- `bundleName`: an optional bundle name, instead of the automatic naming,
 - returns a Promise providing the name of the loaded module
 
 (API is identical generally to the "Lazy loading" feature below)

--- a/src/Bundle.hx
+++ b/src/Bundle.hx
@@ -12,21 +12,26 @@ class Bundle
 	 * Load async application bundle created with `classRef` as entry point
 	 * Note: excution is synchronous in nodejs; the Promise can be ignored
 	 */
-	macro static public function load(classRef:Expr)
+	macro static public function load(classRef:Expr, ?bundleNameExpr:Expr)
 	{
 		switch (Context.typeof(classRef))
 		{
 			case Type.TType(_.get() => t, _):
 				var module = t.module.split('_').join('_$').split('.').join('_');
-				Split.register(module);
-
+				var bundleName = module;
+				if (bundleNameExpr != null) {
+					bundleName = getString(bundleNameExpr);
+					Split.register('$bundleName=$module');
+				} else {
+					Split.register(module);
+				}
 				#if modular_stub
 				return macro ({ then: function(cb) { cb($v{module}); }});
 				#else
 
 				var bridge = macro var _ = untyped $i{module} = $p{["$s", module]};
 				#if nodejs
-				var jsModule = './$module';
+				var jsModule = './$bundleName';
 				return macro cast {
 					untyped require($v{jsModule});
 					$bridge;
@@ -41,7 +46,7 @@ class Bundle
 					#if debug
 					Require.hot(function(_) $bridge, $v{module});
 					#end
-					@:keep Require.module($v{module})
+					@:keep Require.module($v{bundleName})
 						.then(function(_i:String) {
 							$bridge;
 							return _i;
@@ -57,15 +62,6 @@ class Bundle
 
 	macro static public function loadLib(libNameExpr:Expr, pkgListExpr:Expr)
 	{
-		function getString(e:Expr) {
-			switch (e.expr) {
-				case EConst(CString(s)): return s;
-				default:
-					Context.fatalError('String literal expected', e.pos);
-					return null;
-			}
-		}
-
 		var libName = getString(libNameExpr);
 
 		switch (pkgListExpr.expr) {
@@ -98,6 +94,15 @@ class Bundle
 	}
 
 	#if macro
+	static function getString(e:Expr) {
+		switch (e.expr) {
+			case EConst(CString(s)): return s;
+			default:
+				Context.fatalError('String literal expected', e.pos);
+				return null;
+		}
+	}
+
 	static function formatMatch(s:String)
 	{
 		var m = s.split('_').join('_$').split('.').join('_');

--- a/src/Bundle.hx
+++ b/src/Bundle.hx
@@ -20,7 +20,7 @@ class Bundle
 				var module = t.module.split('_').join('_$').split('.').join('_');
 				var bundleName = getStringOption(bundleNameExpr);
 				if (bundleName != null) {
-					Split.register('$bundleName=$module');
+					Split.register('$module>$bundleName');
 				} else {
 					bundleName = module;
 					Split.register(module);

--- a/src/Bundle.hx
+++ b/src/Bundle.hx
@@ -18,11 +18,11 @@ class Bundle
 		{
 			case Type.TType(_.get() => t, _):
 				var module = t.module.split('_').join('_$').split('.').join('_');
-				var bundleName = module;
-				if (bundleNameExpr != null) {
-					bundleName = getString(bundleNameExpr);
+				var bundleName = getStringOption(bundleNameExpr);
+				if (bundleName != null) {
 					Split.register('$bundleName=$module');
 				} else {
+					bundleName = module;
 					Split.register(module);
 				}
 				#if modular_stub
@@ -100,6 +100,13 @@ class Bundle
 			default:
 				Context.fatalError('String literal expected', e.pos);
 				return null;
+		}
+	}
+
+	static function getStringOption(e:Expr) {
+		switch (e.expr) {
+			case EConst(CString(s)): return s;
+			default: return null;
 		}
 	}
 

--- a/src/Bundle.hx
+++ b/src/Bundle.hx
@@ -20,7 +20,7 @@ class Bundle
 				var module = t.module.split('_').join('_$').split('.').join('_');
 				var bundleName = getStringOption(bundleNameExpr);
 				if (bundleName != null) {
-					Split.register('$module>$bundleName');
+					Split.register('$module@$bundleName');
 				} else {
 					bundleName = module;
 					Split.register(module);

--- a/src/Require.hx
+++ b/src/Require.hx
@@ -130,7 +130,7 @@ class Require
 	#end
 
 	#else //webpack
-	static macro public function module(name:Expr):ExprOf<js.Promise<Dynamic>>
+	static macro public function module(name:Expr):ExprOf<Promise<Dynamic>>
 	{
 		var module = switch(name.expr) {
 			case EConst(CString(s)): s;

--- a/tool/bin/split.js
+++ b/tool/bin/split.js
@@ -968,8 +968,8 @@ class Extractor {
 		this.modules = tmp.concat(_g1);
 	}
 	getModuleAlias($module) {
-		if($module.indexOf(">") > 0) {
-			let parts = $module.split(">");
+		if($module.indexOf("@") > 0) {
+			let parts = $module.split("@");
 			this.moduleAlias[parts[0]] = parts[1];
 			return parts[0];
 		}

--- a/tool/bin/split.js
+++ b/tool/bin/split.js
@@ -420,7 +420,17 @@ class Bundler {
 		}
 	}
 	createRevMap(index,bundle) {
-		this.minifyId.set(bundle.name);
+		if(bundle.isLib) {
+			let _g = 0;
+			let _g1 = bundle.libParams;
+			while(_g < _g1.length) {
+				let param = _g1[_g];
+				++_g;
+				this.minifyId.set(param);
+			}
+		} else {
+			this.minifyId.set(bundle.name);
+		}
 		let rev = this.revMap;
 		let nodes = bundle.nodes;
 		let len = nodes.length;
@@ -487,7 +497,7 @@ class Bundler {
 			return Bundler.generateHtml(consumer,src,sourcesContent);
 		} catch( _g5 ) {
 			let err = haxe_Exception.caught(_g5).unwrap();
-			haxe_Log.trace("[WARNING] error while generating debug map for " + bundle.name + ": " + Std.string(err),{ fileName : "tool/src/Bundler.hx", lineNumber : 230, className : "Bundler", methodName : "emitDebugMap"});
+			haxe_Log.trace("[WARNING] error while generating debug map for " + bundle.name + ": " + Std.string(err),{ fileName : "tool/src/Bundler.hx", lineNumber : 236, className : "Bundler", methodName : "emitDebugMap"});
 			return null;
 		}
 	}
@@ -667,13 +677,13 @@ class Extractor {
 	}
 	process(mainModule,modulesList,debugMode) {
 		let t0 = new Date().getTime();
-		haxe_Log.trace("Bundling...",{ fileName : "tool/src/Extractor.hx", lineNumber : 48, className : "Extractor", methodName : "process"});
+		haxe_Log.trace("Bundling...",{ fileName : "tool/src/Extractor.hx", lineNumber : 49, className : "Extractor", methodName : "process"});
 		this.moduleMap = { };
 		this.parenting = new graphlib_Graph();
 		this.moduleTest = { };
 		let _gthis = this;
 		if(this.parser.typesCount == 0) {
-			haxe_Log.trace("Warning: unable to process (no type metadata)",{ fileName : "tool/src/Extractor.hx", lineNumber : 54, className : "Extractor", methodName : "process"});
+			haxe_Log.trace("Warning: unable to process (no type metadata)",{ fileName : "tool/src/Extractor.hx", lineNumber : 55, className : "Extractor", methodName : "process"});
 			this.main = this.createBundle(mainModule);
 			this.bundles = [this.main];
 			return;
@@ -721,7 +731,7 @@ class Extractor {
 		}
 		this.bundles = _g3;
 		let t1 = new Date().getTime();
-		haxe_Log.trace("Graph processed in: " + (t1 - t0) + "ms",{ fileName : "tool/src/Extractor.hx", lineNumber : 91, className : "Extractor", methodName : "process"});
+		haxe_Log.trace("Graph processed in: " + (t1 - t0) + "ms",{ fileName : "tool/src/Extractor.hx", lineNumber : 92, className : "Extractor", methodName : "process"});
 	}
 	populateBundles(mainModule,parents) {
 		let bundle = this.moduleMap[mainModule];
@@ -982,11 +992,11 @@ class Extractor {
 			}
 		}
 	}
-	createBundle(name,isLib) {
+	createBundle(name,isLib,libParams) {
 		if(isLib == null) {
 			isLib = false;
 		}
-		let bundle = { isMain : name == this.mainModule, isLib : isLib, name : name, nodes : [], indexes : [], exports : { }, shared : { }, imports : { }};
+		let bundle = { isMain : name == this.mainModule, isLib : isLib, libParams : libParams, name : name, nodes : [], indexes : [], exports : { }, shared : { }, imports : { }};
 		if(!this.parenting.hasNode(name)) {
 			this.parenting.setNode(name);
 		}
@@ -1032,9 +1042,9 @@ class Extractor {
 	resolveLib(name) {
 		let parts = name.split("=");
 		let newName = parts[0];
-		let tmp = parts[1].split(",");
-		let tmp1 = this.createBundle(newName,true);
-		return { test : tmp, roots : { }, bundle : tmp1};
+		let libParams = parts[1].split(",");
+		let tmp = this.createBundle(newName,true,libParams);
+		return { test : libParams, roots : { }, bundle : tmp};
 	}
 	addOnce(source,target) {
 		let temp = target.slice();
@@ -1977,7 +1987,37 @@ class js_Boot {
 }
 js_Boot.__name__ = true;
 var js_node_Fs = require("fs");
+class js_node_KeyValue {
+	static get_key(this1) {
+		return this1[0];
+	}
+	static get_value(this1) {
+		return this1[1];
+	}
+}
 var js_node_Path = require("path");
+class js_node_stream_WritableNewOptionsAdapter {
+	static from(options) {
+		if(!Object.prototype.hasOwnProperty.call(options,"final")) {
+			Object.defineProperty(options,"final",{ get : function() {
+				return options.final_;
+			}});
+		}
+		return options;
+	}
+}
+class js_node_url_URLSearchParamsEntry {
+	static _new(name,value) {
+		let this1 = [name,value];
+		return this1;
+	}
+	static get_name(this1) {
+		return this1[0];
+	}
+	static get_value(this1) {
+		return this1[1];
+	}
+}
 if(typeof(performance) != "undefined" ? typeof(performance.now) == "function" : false) {
 	HxOverrides.now = performance.now.bind(performance);
 }

--- a/tool/src/Bundler.hx
+++ b/tool/src/Bundler.hx
@@ -91,7 +91,7 @@ class Bundler
 		for (i in 0...len) {
 			final bundle = bundles[i];
 			final isMain = bundle.isMain;
-			final bundleOutput = isMain ? output : Path.join(Path.dirname(output), bundle.name + '.js');
+			final bundleOutput = isMain ? output : Path.join(Path.dirname(output), bundle.alias + '.js');
 			trace('Emit $bundleOutput');
 
 			final buffer = emitBundle(src, bundle, isMain);

--- a/tool/src/Bundler.hx
+++ b/tool/src/Bundler.hx
@@ -168,7 +168,13 @@ class Bundler
 
 	function createRevMap(index:Int, bundle:Bundle)
 	{
-		minifyId.set(bundle.name);
+		// prevent minification of shared refs
+		if (bundle.isLib) {
+			for (param in bundle.libParams) minifyId.set(param);
+		} else {
+			minifyId.set(bundle.name);
+		}
+		// lookup-map between identifiers and bundles
 		final rev = revMap;
 		final nodes = bundle.nodes;
 		final len = nodes.length;

--- a/tool/src/Extractor.hx
+++ b/tool/src/Extractor.hx
@@ -6,6 +6,7 @@ import haxe.DynamicAccess;
 typedef Bundle = {
 	isMain:Bool,
 	isLib:Bool,
+	libParams:Array<String>,
 	name:String,
 	nodes:Array<String>,
 	indexes:Array<Int>,
@@ -301,11 +302,12 @@ class Extractor
 		}
 	}
 
-	function createBundle(name:String, isLib:Bool = false)
+	function createBundle(name:String, isLib:Bool = false, libParams:Array<String> = null)
 	{
 		final bundle:Bundle = {
 			isMain: name == mainModule,
 			isLib: isLib,
+			libParams: libParams,
 			name: name,
 			nodes: [],
 			indexes: [],
@@ -356,10 +358,11 @@ class Extractor
 		// libname=pattern
 		final parts = name.split('=');
 		final newName = parts[0];
+		final libParams = parts[1].split(',');
 		return {
-			test: parts[1].split(','),
+			test: libParams,
 			roots: ({} :DynamicAccess<Bool>),
-			bundle: createBundle(newName, true)
+			bundle: createBundle(newName, true, libParams)
 		};
 	}
 

--- a/tool/src/Extractor.hx
+++ b/tool/src/Extractor.hx
@@ -288,8 +288,8 @@ class Extractor
 
 	function getModuleAlias(module:String)
 	{
-		if (module.indexOf('>') > 0) {
-			final parts = module.split('>');
+		if (module.indexOf('@') > 0) {
+			final parts = module.split('@');
 			moduleAlias.set(parts[0], parts[1]);
 			return parts[0];
 		}

--- a/tool/test/expect/haxe_3/node-debug-test1.json
+++ b/tool/test/expect/haxe_3/node-debug-test1.json
@@ -28,6 +28,7 @@
     "isMain": false,
     "isLib": false,
     "name": "CaseA",
+    "alias": "CaseA",
     "nodes": [
       "CaseA"
     ],
@@ -44,6 +45,7 @@
     "isMain": false,
     "isLib": false,
     "name": "CaseB",
+    "alias": "CaseB",
     "nodes": [
       "CaseB",
       "DepB"

--- a/tool/test/expect/haxe_3/node-debug-test10.json
+++ b/tool/test/expect/haxe_3/node-debug-test10.json
@@ -22,6 +22,7 @@
     "isMain": false,
     "isLib": false,
     "name": "CaseE",
+    "alias": "CaseE",
     "nodes": [
       "CaseE"
     ],
@@ -40,6 +41,7 @@
     "isMain": false,
     "isLib": false,
     "name": "DepE",
+    "alias": "DepE",
     "nodes": [
       "DepE"
     ],

--- a/tool/test/expect/haxe_3/node-debug-test11.json
+++ b/tool/test/expect/haxe_3/node-debug-test11.json
@@ -20,6 +20,7 @@
     "isMain": false,
     "isLib": false,
     "name": "CaseF",
+    "alias": "CaseF",
     "nodes": [
       "$extend",
       "CaseF",

--- a/tool/test/expect/haxe_3/node-debug-test12.json
+++ b/tool/test/expect/haxe_3/node-debug-test12.json
@@ -30,6 +30,7 @@
       "a_$b_C_$_$d"
     ],
     "name": "lib",
+    "alias": "lib",
     "nodes": [
       "a_$b_C_$_$d",
       "lib_DepLib",

--- a/tool/test/expect/haxe_3/node-debug-test12.json
+++ b/tool/test/expect/haxe_3/node-debug-test12.json
@@ -25,6 +25,10 @@
   {
     "isMain": false,
     "isLib": true,
+    "libParams": [
+      "lib_",
+      "a_$b_C_$_$d"
+    ],
     "name": "lib",
     "nodes": [
       "a_$b_C_$_$d",

--- a/tool/test/expect/haxe_3/node-debug-test13.json
+++ b/tool/test/expect/haxe_3/node-debug-test13.json
@@ -20,6 +20,7 @@
     "isMain": false,
     "isLib": false,
     "name": "a_$b_Exposed",
+    "alias": "a_$b_Exposed",
     "nodes": [
       "a_$b_Exposed",
       "a_$b_SubExposed"

--- a/tool/test/expect/haxe_3/node-debug-test14.json
+++ b/tool/test/expect/haxe_3/node-debug-test14.json
@@ -16,6 +16,7 @@
     "isMain": false,
     "isLib": false,
     "name": "a_$b_Exposed",
+    "alias": "a_$b_Exposed",
     "nodes": [
       "a_$b_Exposed",
       "a_$b_SubExposed"

--- a/tool/test/expect/haxe_3/node-debug-test15.json
+++ b/tool/test/expect/haxe_3/node-debug-test15.json
@@ -22,6 +22,7 @@
     "isMain": false,
     "isLib": false,
     "name": "CaseG",
+    "alias": "CaseG",
     "nodes": [
       "CaseG"
     ],

--- a/tool/test/expect/haxe_3/node-debug-test2.json
+++ b/tool/test/expect/haxe_3/node-debug-test2.json
@@ -28,6 +28,7 @@
     "isMain": false,
     "isLib": false,
     "name": "CaseA",
+    "alias": "CaseA",
     "nodes": [
       "CaseA"
     ],
@@ -44,6 +45,7 @@
     "isMain": false,
     "isLib": false,
     "name": "CaseB",
+    "alias": "CaseB",
     "nodes": [
       "CaseB",
       "DepB"

--- a/tool/test/expect/haxe_3/node-debug-test3.json
+++ b/tool/test/expect/haxe_3/node-debug-test3.json
@@ -23,6 +23,7 @@
     "isMain": false,
     "isLib": false,
     "name": "CaseC",
+    "alias": "CaseC",
     "nodes": [
       "CaseC"
     ],
@@ -40,6 +41,7 @@
     "isMain": false,
     "isLib": false,
     "name": "DepC",
+    "alias": "DepC",
     "nodes": [
       "DepC",
       "DepSubC"
@@ -61,6 +63,7 @@
     "isMain": false,
     "isLib": false,
     "name": "SubC",
+    "alias": "SubC",
     "nodes": [
       "SubC"
     ],
@@ -77,6 +80,7 @@
     "isMain": false,
     "isLib": false,
     "name": "SubC2",
+    "alias": "SubC2",
     "nodes": [
       "SubC2"
     ],

--- a/tool/test/expect/haxe_3/node-debug-test4.json
+++ b/tool/test/expect/haxe_3/node-debug-test4.json
@@ -31,24 +31,6 @@
   },
   {
     "isMain": false,
-    "isLib": true,
-    "name": "lib",
-    "nodes": [
-      "lib_DepLib",
-      "lib_Lib",
-      "lib_Lib2"
-    ],
-    "exports": {
-      "lib_Lib": true,
-      "lib_Lib2": true
-    },
-    "shared": {},
-    "imports": {
-      "$hxClasses": true
-    }
-  },
-  {
-    "isMain": false,
     "isLib": false,
     "name": "CaseA",
     "nodes": [
@@ -81,6 +63,27 @@
       "DepDepB": true,
       "$hxClasses": true,
       "lib_Lib2": true
+    }
+  },
+  {
+    "isMain": false,
+    "isLib": true,
+    "libParams": [
+      "lib_"
+    ],
+    "name": "lib",
+    "nodes": [
+      "lib_DepLib",
+      "lib_Lib",
+      "lib_Lib2"
+    ],
+    "exports": {
+      "lib_Lib": true,
+      "lib_Lib2": true
+    },
+    "shared": {},
+    "imports": {
+      "$hxClasses": true
     }
   }
 ]

--- a/tool/test/expect/haxe_3/node-debug-test4.json
+++ b/tool/test/expect/haxe_3/node-debug-test4.json
@@ -33,6 +33,7 @@
     "isMain": false,
     "isLib": false,
     "name": "CaseA",
+    "alias": "CaseA",
     "nodes": [
       "CaseA"
     ],
@@ -50,6 +51,7 @@
     "isMain": false,
     "isLib": false,
     "name": "CaseB",
+    "alias": "CaseB",
     "nodes": [
       "CaseB",
       "DepB"
@@ -72,6 +74,7 @@
       "lib_"
     ],
     "name": "lib",
+    "alias": "lib",
     "nodes": [
       "lib_DepLib",
       "lib_Lib",

--- a/tool/test/expect/haxe_3/node-debug-test5.json
+++ b/tool/test/expect/haxe_3/node-debug-test5.json
@@ -33,26 +33,6 @@
   },
   {
     "isMain": false,
-    "isLib": true,
-    "name": "lib",
-    "nodes": [
-      "a_$b_C_$_$d",
-      "lib_DepLib",
-      "lib_Lib",
-      "lib_Lib2"
-    ],
-    "exports": {
-      "lib_Lib2": true,
-      "a_$b_C_$_$d": true,
-      "lib_Lib": true
-    },
-    "shared": {},
-    "imports": {
-      "$hxClasses": true
-    }
-  },
-  {
-    "isMain": false,
     "isLib": false,
     "name": "CaseA",
     "nodes": [
@@ -85,6 +65,30 @@
       "DepDepB": true,
       "$hxClasses": true,
       "lib_Lib2": true
+    }
+  },
+  {
+    "isMain": false,
+    "isLib": true,
+    "libParams": [
+      "lib_",
+      "a_$b_C_$_$d"
+    ],
+    "name": "lib",
+    "nodes": [
+      "a_$b_C_$_$d",
+      "lib_DepLib",
+      "lib_Lib",
+      "lib_Lib2"
+    ],
+    "exports": {
+      "lib_Lib2": true,
+      "a_$b_C_$_$d": true,
+      "lib_Lib": true
+    },
+    "shared": {},
+    "imports": {
+      "$hxClasses": true
     }
   }
 ]

--- a/tool/test/expect/haxe_3/node-debug-test5.json
+++ b/tool/test/expect/haxe_3/node-debug-test5.json
@@ -35,6 +35,7 @@
     "isMain": false,
     "isLib": false,
     "name": "CaseA",
+    "alias": "CaseA",
     "nodes": [
       "CaseA"
     ],
@@ -52,6 +53,7 @@
     "isMain": false,
     "isLib": false,
     "name": "CaseB",
+    "alias": "CaseB",
     "nodes": [
       "CaseB",
       "DepB"
@@ -75,6 +77,7 @@
       "a_$b_C_$_$d"
     ],
     "name": "lib",
+    "alias": "lib",
     "nodes": [
       "a_$b_C_$_$d",
       "lib_DepLib",

--- a/tool/test/expect/haxe_3/node-debug-test6.json
+++ b/tool/test/expect/haxe_3/node-debug-test6.json
@@ -23,6 +23,7 @@
     "isMain": false,
     "isLib": false,
     "name": "CaseA",
+    "alias": "CaseA",
     "nodes": [
       "CaseA",
       "DepAB",

--- a/tool/test/expect/haxe_3/node-debug-test7.json
+++ b/tool/test/expect/haxe_3/node-debug-test7.json
@@ -20,6 +20,7 @@
     "isMain": false,
     "isLib": false,
     "name": "CaseD",
+    "alias": "CaseD",
     "nodes": [
       "CaseD",
       "CycleD"

--- a/tool/test/expect/haxe_3/node-debug-test9.json
+++ b/tool/test/expect/haxe_3/node-debug-test9.json
@@ -20,6 +20,7 @@
     "isMain": false,
     "isLib": false,
     "name": "CaseD",
+    "alias": "CaseD",
     "nodes": [
       "CaseD",
       "CycleD"

--- a/tool/test/expect/haxe_3/node-release-test1.json
+++ b/tool/test/expect/haxe_3/node-release-test1.json
@@ -27,6 +27,7 @@
     "isMain": false,
     "isLib": false,
     "name": "CaseA",
+    "alias": "CaseA",
     "nodes": [
       "CaseA"
     ],
@@ -43,6 +44,7 @@
     "isMain": false,
     "isLib": false,
     "name": "CaseB",
+    "alias": "CaseB",
     "nodes": [
       "CaseB",
       "DepB",

--- a/tool/test/expect/haxe_3/node-release-test10.json
+++ b/tool/test/expect/haxe_3/node-release-test10.json
@@ -22,6 +22,7 @@
     "isMain": false,
     "isLib": false,
     "name": "CaseE",
+    "alias": "CaseE",
     "nodes": [
       "CaseE"
     ],
@@ -40,6 +41,7 @@
     "isMain": false,
     "isLib": false,
     "name": "DepE",
+    "alias": "DepE",
     "nodes": [
       "DepE"
     ],

--- a/tool/test/expect/haxe_3/node-release-test11.json
+++ b/tool/test/expect/haxe_3/node-release-test11.json
@@ -20,6 +20,7 @@
     "isMain": false,
     "isLib": false,
     "name": "CaseF",
+    "alias": "CaseF",
     "nodes": [
       "$extend",
       "CaseF",

--- a/tool/test/expect/haxe_3/node-release-test12.json
+++ b/tool/test/expect/haxe_3/node-release-test12.json
@@ -30,6 +30,7 @@
       "a_$b_C_$_$d"
     ],
     "name": "lib",
+    "alias": "lib",
     "nodes": [
       "a_$b_C_$_$d",
       "lib_DepLib",

--- a/tool/test/expect/haxe_3/node-release-test12.json
+++ b/tool/test/expect/haxe_3/node-release-test12.json
@@ -25,6 +25,10 @@
   {
     "isMain": false,
     "isLib": true,
+    "libParams": [
+      "lib_",
+      "a_$b_C_$_$d"
+    ],
     "name": "lib",
     "nodes": [
       "a_$b_C_$_$d",

--- a/tool/test/expect/haxe_3/node-release-test13.json
+++ b/tool/test/expect/haxe_3/node-release-test13.json
@@ -20,6 +20,7 @@
     "isMain": false,
     "isLib": false,
     "name": "a_$b_Exposed",
+    "alias": "a_$b_Exposed",
     "nodes": [
       "a_$b_Exposed",
       "a_$b_SubExposed"

--- a/tool/test/expect/haxe_3/node-release-test14.json
+++ b/tool/test/expect/haxe_3/node-release-test14.json
@@ -16,6 +16,7 @@
     "isMain": false,
     "isLib": false,
     "name": "a_$b_Exposed",
+    "alias": "a_$b_Exposed",
     "nodes": [
       "a_$b_Exposed",
       "a_$b_SubExposed"

--- a/tool/test/expect/haxe_3/node-release-test15.json
+++ b/tool/test/expect/haxe_3/node-release-test15.json
@@ -22,6 +22,7 @@
     "isMain": false,
     "isLib": false,
     "name": "CaseG",
+    "alias": "CaseG",
     "nodes": [
       "CaseG"
     ],

--- a/tool/test/expect/haxe_3/node-release-test2.json
+++ b/tool/test/expect/haxe_3/node-release-test2.json
@@ -27,6 +27,7 @@
     "isMain": false,
     "isLib": false,
     "name": "CaseA",
+    "alias": "CaseA",
     "nodes": [
       "CaseA"
     ],
@@ -43,6 +44,7 @@
     "isMain": false,
     "isLib": false,
     "name": "CaseB",
+    "alias": "CaseB",
     "nodes": [
       "CaseB",
       "DepB",

--- a/tool/test/expect/haxe_3/node-release-test3.json
+++ b/tool/test/expect/haxe_3/node-release-test3.json
@@ -23,6 +23,7 @@
     "isMain": false,
     "isLib": false,
     "name": "CaseC",
+    "alias": "CaseC",
     "nodes": [
       "CaseC"
     ],
@@ -40,6 +41,7 @@
     "isMain": false,
     "isLib": false,
     "name": "DepC",
+    "alias": "DepC",
     "nodes": [
       "DepC",
       "DepSubC"
@@ -61,6 +63,7 @@
     "isMain": false,
     "isLib": false,
     "name": "SubC",
+    "alias": "SubC",
     "nodes": [
       "SubC"
     ],
@@ -77,6 +80,7 @@
     "isMain": false,
     "isLib": false,
     "name": "SubC2",
+    "alias": "SubC2",
     "nodes": [
       "SubC2"
     ],

--- a/tool/test/expect/haxe_3/node-release-test4.json
+++ b/tool/test/expect/haxe_3/node-release-test4.json
@@ -32,6 +32,7 @@
     "isMain": false,
     "isLib": false,
     "name": "CaseA",
+    "alias": "CaseA",
     "nodes": [
       "CaseA"
     ],
@@ -49,6 +50,7 @@
     "isMain": false,
     "isLib": false,
     "name": "CaseB",
+    "alias": "CaseB",
     "nodes": [
       "CaseB",
       "DepB",
@@ -72,6 +74,7 @@
       "lib_"
     ],
     "name": "lib",
+    "alias": "lib",
     "nodes": [
       "lib_DepLib",
       "lib_Lib",

--- a/tool/test/expect/haxe_3/node-release-test4.json
+++ b/tool/test/expect/haxe_3/node-release-test4.json
@@ -30,24 +30,6 @@
   },
   {
     "isMain": false,
-    "isLib": true,
-    "name": "lib",
-    "nodes": [
-      "lib_DepLib",
-      "lib_Lib",
-      "lib_Lib2"
-    ],
-    "exports": {
-      "lib_Lib": true,
-      "lib_Lib2": true
-    },
-    "shared": {},
-    "imports": {
-      "$hxClasses": true
-    }
-  },
-  {
-    "isMain": false,
     "isLib": false,
     "name": "CaseA",
     "nodes": [
@@ -81,6 +63,27 @@
       "$estr": true,
       "$hxClasses": true,
       "lib_Lib2": true
+    }
+  },
+  {
+    "isMain": false,
+    "isLib": true,
+    "libParams": [
+      "lib_"
+    ],
+    "name": "lib",
+    "nodes": [
+      "lib_DepLib",
+      "lib_Lib",
+      "lib_Lib2"
+    ],
+    "exports": {
+      "lib_Lib": true,
+      "lib_Lib2": true
+    },
+    "shared": {},
+    "imports": {
+      "$hxClasses": true
     }
   }
 ]

--- a/tool/test/expect/haxe_3/node-release-test5.json
+++ b/tool/test/expect/haxe_3/node-release-test5.json
@@ -32,26 +32,6 @@
   },
   {
     "isMain": false,
-    "isLib": true,
-    "name": "lib",
-    "nodes": [
-      "a_$b_C_$_$d",
-      "lib_DepLib",
-      "lib_Lib",
-      "lib_Lib2"
-    ],
-    "exports": {
-      "lib_Lib2": true,
-      "a_$b_C_$_$d": true,
-      "lib_Lib": true
-    },
-    "shared": {},
-    "imports": {
-      "$hxClasses": true
-    }
-  },
-  {
-    "isMain": false,
     "isLib": false,
     "name": "CaseA",
     "nodes": [
@@ -85,6 +65,30 @@
       "$estr": true,
       "$hxClasses": true,
       "lib_Lib2": true
+    }
+  },
+  {
+    "isMain": false,
+    "isLib": true,
+    "libParams": [
+      "lib_",
+      "a_$b_C_$_$d"
+    ],
+    "name": "lib",
+    "nodes": [
+      "a_$b_C_$_$d",
+      "lib_DepLib",
+      "lib_Lib",
+      "lib_Lib2"
+    ],
+    "exports": {
+      "lib_Lib2": true,
+      "a_$b_C_$_$d": true,
+      "lib_Lib": true
+    },
+    "shared": {},
+    "imports": {
+      "$hxClasses": true
     }
   }
 ]

--- a/tool/test/expect/haxe_3/node-release-test5.json
+++ b/tool/test/expect/haxe_3/node-release-test5.json
@@ -34,6 +34,7 @@
     "isMain": false,
     "isLib": false,
     "name": "CaseA",
+    "alias": "CaseA",
     "nodes": [
       "CaseA"
     ],
@@ -51,6 +52,7 @@
     "isMain": false,
     "isLib": false,
     "name": "CaseB",
+    "alias": "CaseB",
     "nodes": [
       "CaseB",
       "DepB",
@@ -75,6 +77,7 @@
       "a_$b_C_$_$d"
     ],
     "name": "lib",
+    "alias": "lib",
     "nodes": [
       "a_$b_C_$_$d",
       "lib_DepLib",

--- a/tool/test/expect/haxe_3/node-release-test6.json
+++ b/tool/test/expect/haxe_3/node-release-test6.json
@@ -23,6 +23,7 @@
     "isMain": false,
     "isLib": false,
     "name": "CaseA",
+    "alias": "CaseA",
     "nodes": [
       "CaseA",
       "DepAB",

--- a/tool/test/expect/haxe_3/node-release-test7.json
+++ b/tool/test/expect/haxe_3/node-release-test7.json
@@ -20,6 +20,7 @@
     "isMain": false,
     "isLib": false,
     "name": "CaseD",
+    "alias": "CaseD",
     "nodes": [
       "CaseD",
       "CycleD"

--- a/tool/test/expect/haxe_3/node-release-test9.json
+++ b/tool/test/expect/haxe_3/node-release-test9.json
@@ -20,6 +20,7 @@
     "isMain": false,
     "isLib": false,
     "name": "CaseD",
+    "alias": "CaseD",
     "nodes": [
       "CaseD",
       "CycleD"

--- a/tool/test/expect/haxe_3/web-debug-closure-testinterop.json
+++ b/tool/test/expect/haxe_3/web-debug-closure-testinterop.json
@@ -43,6 +43,7 @@
     "isMain": false,
     "isLib": false,
     "name": "CaseInterop",
+    "alias": "CaseInterop",
     "nodes": [
       "ArrayBuffer",
       "CaseInterop",
@@ -76,6 +77,7 @@
     "isMain": false,
     "isLib": false,
     "name": "a_$b_C_$_$d",
+    "alias": "a_$b_C_$_$d",
     "nodes": [
       "a_$b_C_$_$d"
     ],

--- a/tool/test/expect/haxe_3/web-debug-test1.json
+++ b/tool/test/expect/haxe_3/web-debug-test1.json
@@ -34,6 +34,7 @@
     "isMain": false,
     "isLib": false,
     "name": "CaseA",
+    "alias": "CaseA",
     "nodes": [
       "CaseA"
     ],
@@ -50,6 +51,7 @@
     "isMain": false,
     "isLib": false,
     "name": "CaseB",
+    "alias": "CaseB",
     "nodes": [
       "CaseB",
       "DepB"

--- a/tool/test/expect/haxe_3/web-debug-test10.json
+++ b/tool/test/expect/haxe_3/web-debug-test10.json
@@ -30,6 +30,7 @@
     "isMain": false,
     "isLib": false,
     "name": "CaseE",
+    "alias": "CaseE",
     "nodes": [
       "CaseE"
     ],
@@ -49,6 +50,7 @@
     "isMain": false,
     "isLib": false,
     "name": "DepE",
+    "alias": "DepE",
     "nodes": [
       "DepE"
     ],

--- a/tool/test/expect/haxe_3/web-debug-test11.json
+++ b/tool/test/expect/haxe_3/web-debug-test11.json
@@ -27,6 +27,7 @@
     "isMain": false,
     "isLib": false,
     "name": "CaseF",
+    "alias": "CaseF",
     "nodes": [
       "$extend",
       "CaseF",

--- a/tool/test/expect/haxe_3/web-debug-test12.json
+++ b/tool/test/expect/haxe_3/web-debug-test12.json
@@ -26,6 +26,10 @@
   {
     "isMain": false,
     "isLib": true,
+    "libParams": [
+      "lib_",
+      "a_$b_C_$_$d"
+    ],
     "name": "lib",
     "nodes": [
       "a_$b_C_$_$d",

--- a/tool/test/expect/haxe_3/web-debug-test12.json
+++ b/tool/test/expect/haxe_3/web-debug-test12.json
@@ -31,6 +31,7 @@
       "a_$b_C_$_$d"
     ],
     "name": "lib",
+    "alias": "lib",
     "nodes": [
       "a_$b_C_$_$d",
       "lib_DepLib",

--- a/tool/test/expect/haxe_3/web-debug-test13.json
+++ b/tool/test/expect/haxe_3/web-debug-test13.json
@@ -27,6 +27,7 @@
     "isMain": false,
     "isLib": false,
     "name": "a_$b_Exposed",
+    "alias": "a_$b_Exposed",
     "nodes": [
       "a_$b_Exposed",
       "a_$b_SubExposed"

--- a/tool/test/expect/haxe_3/web-debug-test14.json
+++ b/tool/test/expect/haxe_3/web-debug-test14.json
@@ -23,6 +23,7 @@
     "isMain": false,
     "isLib": false,
     "name": "a_$b_Exposed",
+    "alias": "a_$b_Exposed",
     "nodes": [
       "a_$b_Exposed",
       "a_$b_SubExposed"

--- a/tool/test/expect/haxe_3/web-debug-test15.json
+++ b/tool/test/expect/haxe_3/web-debug-test15.json
@@ -29,6 +29,7 @@
     "isMain": false,
     "isLib": false,
     "name": "CaseG",
+    "alias": "CaseG",
     "nodes": [
       "CaseG"
     ],

--- a/tool/test/expect/haxe_3/web-debug-test2.json
+++ b/tool/test/expect/haxe_3/web-debug-test2.json
@@ -34,6 +34,7 @@
     "isMain": false,
     "isLib": false,
     "name": "CaseA",
+    "alias": "CaseA",
     "nodes": [
       "CaseA"
     ],
@@ -50,6 +51,7 @@
     "isMain": false,
     "isLib": false,
     "name": "CaseB",
+    "alias": "CaseB",
     "nodes": [
       "CaseB",
       "DepB"

--- a/tool/test/expect/haxe_3/web-debug-test3.json
+++ b/tool/test/expect/haxe_3/web-debug-test3.json
@@ -31,6 +31,7 @@
     "isMain": false,
     "isLib": false,
     "name": "CaseC",
+    "alias": "CaseC",
     "nodes": [
       "CaseC"
     ],
@@ -49,6 +50,7 @@
     "isMain": false,
     "isLib": false,
     "name": "DepC",
+    "alias": "DepC",
     "nodes": [
       "DepC",
       "DepSubC"
@@ -71,6 +73,7 @@
     "isMain": false,
     "isLib": false,
     "name": "SubC",
+    "alias": "SubC",
     "nodes": [
       "SubC"
     ],
@@ -87,6 +90,7 @@
     "isMain": false,
     "isLib": false,
     "name": "SubC2",
+    "alias": "SubC2",
     "nodes": [
       "SubC2"
     ],

--- a/tool/test/expect/haxe_3/web-debug-test4.json
+++ b/tool/test/expect/haxe_3/web-debug-test4.json
@@ -34,24 +34,6 @@
   },
   {
     "isMain": false,
-    "isLib": true,
-    "name": "lib",
-    "nodes": [
-      "lib_DepLib",
-      "lib_Lib",
-      "lib_Lib2"
-    ],
-    "exports": {
-      "lib_Lib": true,
-      "lib_Lib2": true
-    },
-    "shared": {},
-    "imports": {
-      "$hxClasses": true
-    }
-  },
-  {
-    "isMain": false,
     "isLib": false,
     "name": "CaseA",
     "nodes": [
@@ -84,6 +66,27 @@
       "DepDepB": true,
       "$hxClasses": true,
       "lib_Lib2": true
+    }
+  },
+  {
+    "isMain": false,
+    "isLib": true,
+    "libParams": [
+      "lib_"
+    ],
+    "name": "lib",
+    "nodes": [
+      "lib_DepLib",
+      "lib_Lib",
+      "lib_Lib2"
+    ],
+    "exports": {
+      "lib_Lib": true,
+      "lib_Lib2": true
+    },
+    "shared": {},
+    "imports": {
+      "$hxClasses": true
     }
   }
 ]

--- a/tool/test/expect/haxe_3/web-debug-test4.json
+++ b/tool/test/expect/haxe_3/web-debug-test4.json
@@ -36,6 +36,7 @@
     "isMain": false,
     "isLib": false,
     "name": "CaseA",
+    "alias": "CaseA",
     "nodes": [
       "CaseA"
     ],
@@ -53,6 +54,7 @@
     "isMain": false,
     "isLib": false,
     "name": "CaseB",
+    "alias": "CaseB",
     "nodes": [
       "CaseB",
       "DepB"
@@ -75,6 +77,7 @@
       "lib_"
     ],
     "name": "lib",
+    "alias": "lib",
     "nodes": [
       "lib_DepLib",
       "lib_Lib",

--- a/tool/test/expect/haxe_3/web-debug-test5.json
+++ b/tool/test/expect/haxe_3/web-debug-test5.json
@@ -38,6 +38,7 @@
     "isMain": false,
     "isLib": false,
     "name": "CaseA",
+    "alias": "CaseA",
     "nodes": [
       "CaseA"
     ],
@@ -55,6 +56,7 @@
     "isMain": false,
     "isLib": false,
     "name": "CaseB",
+    "alias": "CaseB",
     "nodes": [
       "CaseB",
       "DepB"
@@ -78,6 +80,7 @@
       "a_$b_C_$_$d"
     ],
     "name": "lib",
+    "alias": "lib",
     "nodes": [
       "a_$b_C_$_$d",
       "lib_DepLib",

--- a/tool/test/expect/haxe_3/web-debug-test5.json
+++ b/tool/test/expect/haxe_3/web-debug-test5.json
@@ -36,26 +36,6 @@
   },
   {
     "isMain": false,
-    "isLib": true,
-    "name": "lib",
-    "nodes": [
-      "a_$b_C_$_$d",
-      "lib_DepLib",
-      "lib_Lib",
-      "lib_Lib2"
-    ],
-    "exports": {
-      "lib_Lib2": true,
-      "a_$b_C_$_$d": true,
-      "lib_Lib": true
-    },
-    "shared": {},
-    "imports": {
-      "$hxClasses": true
-    }
-  },
-  {
-    "isMain": false,
     "isLib": false,
     "name": "CaseA",
     "nodes": [
@@ -88,6 +68,30 @@
       "DepDepB": true,
       "$hxClasses": true,
       "lib_Lib2": true
+    }
+  },
+  {
+    "isMain": false,
+    "isLib": true,
+    "libParams": [
+      "lib_",
+      "a_$b_C_$_$d"
+    ],
+    "name": "lib",
+    "nodes": [
+      "a_$b_C_$_$d",
+      "lib_DepLib",
+      "lib_Lib",
+      "lib_Lib2"
+    ],
+    "exports": {
+      "lib_Lib2": true,
+      "a_$b_C_$_$d": true,
+      "lib_Lib": true
+    },
+    "shared": {},
+    "imports": {
+      "$hxClasses": true
     }
   }
 ]

--- a/tool/test/expect/haxe_3/web-debug-test6.json
+++ b/tool/test/expect/haxe_3/web-debug-test6.json
@@ -30,6 +30,7 @@
     "isMain": false,
     "isLib": false,
     "name": "CaseA",
+    "alias": "CaseA",
     "nodes": [
       "CaseA",
       "DepAB",

--- a/tool/test/expect/haxe_3/web-debug-test7.json
+++ b/tool/test/expect/haxe_3/web-debug-test7.json
@@ -27,6 +27,7 @@
     "isMain": false,
     "isLib": false,
     "name": "CaseD",
+    "alias": "CaseD",
     "nodes": [
       "CaseD",
       "CycleD"

--- a/tool/test/expect/haxe_3/web-debug-test9.json
+++ b/tool/test/expect/haxe_3/web-debug-test9.json
@@ -27,6 +27,7 @@
     "isMain": false,
     "isLib": false,
     "name": "CaseD",
+    "alias": "CaseD",
     "nodes": [
       "CaseD",
       "CycleD"

--- a/tool/test/expect/haxe_3/web-debug-testinterop.json
+++ b/tool/test/expect/haxe_3/web-debug-testinterop.json
@@ -43,6 +43,7 @@
     "isMain": false,
     "isLib": false,
     "name": "CaseInterop",
+    "alias": "CaseInterop",
     "nodes": [
       "ArrayBuffer",
       "CaseInterop",
@@ -76,6 +77,7 @@
     "isMain": false,
     "isLib": false,
     "name": "a_$b_C_$_$d",
+    "alias": "a_$b_C_$_$d",
     "nodes": [
       "a_$b_C_$_$d"
     ],

--- a/tool/test/expect/haxe_3/web-debug-uglify-testinterop.json
+++ b/tool/test/expect/haxe_3/web-debug-uglify-testinterop.json
@@ -43,6 +43,7 @@
     "isMain": false,
     "isLib": false,
     "name": "CaseInterop",
+    "alias": "CaseInterop",
     "nodes": [
       "ArrayBuffer",
       "CaseInterop",
@@ -76,6 +77,7 @@
     "isMain": false,
     "isLib": false,
     "name": "a_$b_C_$_$d",
+    "alias": "a_$b_C_$_$d",
     "nodes": [
       "a_$b_C_$_$d"
     ],

--- a/tool/test/expect/haxe_3/web-release-closure-testinterop.json
+++ b/tool/test/expect/haxe_3/web-release-closure-testinterop.json
@@ -40,6 +40,7 @@
     "isMain": false,
     "isLib": false,
     "name": "CaseInterop",
+    "alias": "CaseInterop",
     "nodes": [
       "ArrayBuffer",
       "CaseInterop",
@@ -73,6 +74,7 @@
     "isMain": false,
     "isLib": false,
     "name": "a_$b_C_$_$d",
+    "alias": "a_$b_C_$_$d",
     "nodes": [
       "a_$b_C_$_$d"
     ],

--- a/tool/test/expect/haxe_3/web-release-test1.json
+++ b/tool/test/expect/haxe_3/web-release-test1.json
@@ -31,6 +31,7 @@
     "isMain": false,
     "isLib": false,
     "name": "CaseA",
+    "alias": "CaseA",
     "nodes": [
       "CaseA"
     ],
@@ -47,6 +48,7 @@
     "isMain": false,
     "isLib": false,
     "name": "CaseB",
+    "alias": "CaseB",
     "nodes": [
       "CaseB",
       "DepB",

--- a/tool/test/expect/haxe_3/web-release-test10.json
+++ b/tool/test/expect/haxe_3/web-release-test10.json
@@ -27,6 +27,7 @@
     "isMain": false,
     "isLib": false,
     "name": "CaseE",
+    "alias": "CaseE",
     "nodes": [
       "CaseE"
     ],
@@ -46,6 +47,7 @@
     "isMain": false,
     "isLib": false,
     "name": "DepE",
+    "alias": "DepE",
     "nodes": [
       "DepE"
     ],

--- a/tool/test/expect/haxe_3/web-release-test11.json
+++ b/tool/test/expect/haxe_3/web-release-test11.json
@@ -24,6 +24,7 @@
     "isMain": false,
     "isLib": false,
     "name": "CaseF",
+    "alias": "CaseF",
     "nodes": [
       "$extend",
       "CaseF",

--- a/tool/test/expect/haxe_3/web-release-test12.json
+++ b/tool/test/expect/haxe_3/web-release-test12.json
@@ -26,6 +26,10 @@
   {
     "isMain": false,
     "isLib": true,
+    "libParams": [
+      "lib_",
+      "a_$b_C_$_$d"
+    ],
     "name": "lib",
     "nodes": [
       "a_$b_C_$_$d",

--- a/tool/test/expect/haxe_3/web-release-test12.json
+++ b/tool/test/expect/haxe_3/web-release-test12.json
@@ -31,6 +31,7 @@
       "a_$b_C_$_$d"
     ],
     "name": "lib",
+    "alias": "lib",
     "nodes": [
       "a_$b_C_$_$d",
       "lib_DepLib",

--- a/tool/test/expect/haxe_3/web-release-test13.json
+++ b/tool/test/expect/haxe_3/web-release-test13.json
@@ -24,6 +24,7 @@
     "isMain": false,
     "isLib": false,
     "name": "a_$b_Exposed",
+    "alias": "a_$b_Exposed",
     "nodes": [
       "a_$b_Exposed",
       "a_$b_SubExposed"

--- a/tool/test/expect/haxe_3/web-release-test14.json
+++ b/tool/test/expect/haxe_3/web-release-test14.json
@@ -20,6 +20,7 @@
     "isMain": false,
     "isLib": false,
     "name": "a_$b_Exposed",
+    "alias": "a_$b_Exposed",
     "nodes": [
       "a_$b_Exposed",
       "a_$b_SubExposed"

--- a/tool/test/expect/haxe_3/web-release-test15.json
+++ b/tool/test/expect/haxe_3/web-release-test15.json
@@ -26,6 +26,7 @@
     "isMain": false,
     "isLib": false,
     "name": "CaseG",
+    "alias": "CaseG",
     "nodes": [
       "CaseG"
     ],

--- a/tool/test/expect/haxe_3/web-release-test2.json
+++ b/tool/test/expect/haxe_3/web-release-test2.json
@@ -31,6 +31,7 @@
     "isMain": false,
     "isLib": false,
     "name": "CaseA",
+    "alias": "CaseA",
     "nodes": [
       "CaseA"
     ],
@@ -47,6 +48,7 @@
     "isMain": false,
     "isLib": false,
     "name": "CaseB",
+    "alias": "CaseB",
     "nodes": [
       "CaseB",
       "DepB",

--- a/tool/test/expect/haxe_3/web-release-test3.json
+++ b/tool/test/expect/haxe_3/web-release-test3.json
@@ -28,6 +28,7 @@
     "isMain": false,
     "isLib": false,
     "name": "CaseC",
+    "alias": "CaseC",
     "nodes": [
       "CaseC"
     ],
@@ -46,6 +47,7 @@
     "isMain": false,
     "isLib": false,
     "name": "DepC",
+    "alias": "DepC",
     "nodes": [
       "DepC",
       "DepSubC"
@@ -68,6 +70,7 @@
     "isMain": false,
     "isLib": false,
     "name": "SubC",
+    "alias": "SubC",
     "nodes": [
       "SubC"
     ],
@@ -84,6 +87,7 @@
     "isMain": false,
     "isLib": false,
     "name": "SubC2",
+    "alias": "SubC2",
     "nodes": [
       "SubC2"
     ],

--- a/tool/test/expect/haxe_3/web-release-test4.json
+++ b/tool/test/expect/haxe_3/web-release-test4.json
@@ -31,24 +31,6 @@
   },
   {
     "isMain": false,
-    "isLib": true,
-    "name": "lib",
-    "nodes": [
-      "lib_DepLib",
-      "lib_Lib",
-      "lib_Lib2"
-    ],
-    "exports": {
-      "lib_Lib": true,
-      "lib_Lib2": true
-    },
-    "shared": {},
-    "imports": {
-      "$hxClasses": true
-    }
-  },
-  {
-    "isMain": false,
     "isLib": false,
     "name": "CaseA",
     "nodes": [
@@ -82,6 +64,27 @@
       "$estr": true,
       "$hxClasses": true,
       "lib_Lib2": true
+    }
+  },
+  {
+    "isMain": false,
+    "isLib": true,
+    "libParams": [
+      "lib_"
+    ],
+    "name": "lib",
+    "nodes": [
+      "lib_DepLib",
+      "lib_Lib",
+      "lib_Lib2"
+    ],
+    "exports": {
+      "lib_Lib": true,
+      "lib_Lib2": true
+    },
+    "shared": {},
+    "imports": {
+      "$hxClasses": true
     }
   }
 ]

--- a/tool/test/expect/haxe_3/web-release-test4.json
+++ b/tool/test/expect/haxe_3/web-release-test4.json
@@ -33,6 +33,7 @@
     "isMain": false,
     "isLib": false,
     "name": "CaseA",
+    "alias": "CaseA",
     "nodes": [
       "CaseA"
     ],
@@ -50,6 +51,7 @@
     "isMain": false,
     "isLib": false,
     "name": "CaseB",
+    "alias": "CaseB",
     "nodes": [
       "CaseB",
       "DepB",
@@ -73,6 +75,7 @@
       "lib_"
     ],
     "name": "lib",
+    "alias": "lib",
     "nodes": [
       "lib_DepLib",
       "lib_Lib",

--- a/tool/test/expect/haxe_3/web-release-test5.json
+++ b/tool/test/expect/haxe_3/web-release-test5.json
@@ -35,6 +35,7 @@
     "isMain": false,
     "isLib": false,
     "name": "CaseA",
+    "alias": "CaseA",
     "nodes": [
       "CaseA"
     ],
@@ -52,6 +53,7 @@
     "isMain": false,
     "isLib": false,
     "name": "CaseB",
+    "alias": "CaseB",
     "nodes": [
       "CaseB",
       "DepB",
@@ -76,6 +78,7 @@
       "a_$b_C_$_$d"
     ],
     "name": "lib",
+    "alias": "lib",
     "nodes": [
       "a_$b_C_$_$d",
       "lib_DepLib",

--- a/tool/test/expect/haxe_3/web-release-test5.json
+++ b/tool/test/expect/haxe_3/web-release-test5.json
@@ -33,26 +33,6 @@
   },
   {
     "isMain": false,
-    "isLib": true,
-    "name": "lib",
-    "nodes": [
-      "a_$b_C_$_$d",
-      "lib_DepLib",
-      "lib_Lib",
-      "lib_Lib2"
-    ],
-    "exports": {
-      "lib_Lib2": true,
-      "a_$b_C_$_$d": true,
-      "lib_Lib": true
-    },
-    "shared": {},
-    "imports": {
-      "$hxClasses": true
-    }
-  },
-  {
-    "isMain": false,
     "isLib": false,
     "name": "CaseA",
     "nodes": [
@@ -86,6 +66,30 @@
       "$estr": true,
       "$hxClasses": true,
       "lib_Lib2": true
+    }
+  },
+  {
+    "isMain": false,
+    "isLib": true,
+    "libParams": [
+      "lib_",
+      "a_$b_C_$_$d"
+    ],
+    "name": "lib",
+    "nodes": [
+      "a_$b_C_$_$d",
+      "lib_DepLib",
+      "lib_Lib",
+      "lib_Lib2"
+    ],
+    "exports": {
+      "lib_Lib2": true,
+      "a_$b_C_$_$d": true,
+      "lib_Lib": true
+    },
+    "shared": {},
+    "imports": {
+      "$hxClasses": true
     }
   }
 ]

--- a/tool/test/expect/haxe_3/web-release-test6.json
+++ b/tool/test/expect/haxe_3/web-release-test6.json
@@ -27,6 +27,7 @@
     "isMain": false,
     "isLib": false,
     "name": "CaseA",
+    "alias": "CaseA",
     "nodes": [
       "CaseA",
       "DepAB",

--- a/tool/test/expect/haxe_3/web-release-test7.json
+++ b/tool/test/expect/haxe_3/web-release-test7.json
@@ -24,6 +24,7 @@
     "isMain": false,
     "isLib": false,
     "name": "CaseD",
+    "alias": "CaseD",
     "nodes": [
       "CaseD",
       "CycleD"

--- a/tool/test/expect/haxe_3/web-release-test9.json
+++ b/tool/test/expect/haxe_3/web-release-test9.json
@@ -24,6 +24,7 @@
     "isMain": false,
     "isLib": false,
     "name": "CaseD",
+    "alias": "CaseD",
     "nodes": [
       "CaseD",
       "CycleD"

--- a/tool/test/expect/haxe_3/web-release-testinterop.json
+++ b/tool/test/expect/haxe_3/web-release-testinterop.json
@@ -40,6 +40,7 @@
     "isMain": false,
     "isLib": false,
     "name": "CaseInterop",
+    "alias": "CaseInterop",
     "nodes": [
       "ArrayBuffer",
       "CaseInterop",
@@ -73,6 +74,7 @@
     "isMain": false,
     "isLib": false,
     "name": "a_$b_C_$_$d",
+    "alias": "a_$b_C_$_$d",
     "nodes": [
       "a_$b_C_$_$d"
     ],

--- a/tool/test/expect/haxe_3/web-release-uglify-testinterop.json
+++ b/tool/test/expect/haxe_3/web-release-uglify-testinterop.json
@@ -40,6 +40,7 @@
     "isMain": false,
     "isLib": false,
     "name": "CaseInterop",
+    "alias": "CaseInterop",
     "nodes": [
       "ArrayBuffer",
       "CaseInterop",
@@ -73,6 +74,7 @@
     "isMain": false,
     "isLib": false,
     "name": "a_$b_C_$_$d",
+    "alias": "a_$b_C_$_$d",
     "nodes": [
       "a_$b_C_$_$d"
     ],

--- a/tool/test/expect/haxe_4/node-debug-test1.json
+++ b/tool/test/expect/haxe_4/node-debug-test1.json
@@ -30,6 +30,7 @@
     "isMain": false,
     "isLib": false,
     "name": "CaseA",
+    "alias": "CaseA",
     "nodes": [
       "CaseA"
     ],
@@ -46,6 +47,7 @@
     "isMain": false,
     "isLib": false,
     "name": "CaseB",
+    "alias": "CaseB",
     "nodes": [
       "CaseB",
       "DepB"

--- a/tool/test/expect/haxe_4/node-debug-test10.json
+++ b/tool/test/expect/haxe_4/node-debug-test10.json
@@ -21,6 +21,7 @@
     "isMain": false,
     "isLib": false,
     "name": "CaseE",
+    "alias": "CaseE",
     "nodes": [
       "CaseE"
     ],
@@ -39,6 +40,7 @@
     "isMain": false,
     "isLib": false,
     "name": "DepE",
+    "alias": "DepE",
     "nodes": [
       "DepE"
     ],

--- a/tool/test/expect/haxe_4/node-debug-test11.json
+++ b/tool/test/expect/haxe_4/node-debug-test11.json
@@ -19,6 +19,7 @@
     "isMain": false,
     "isLib": false,
     "name": "CaseF",
+    "alias": "CaseF",
     "nodes": [
       "$extend",
       "CaseF",

--- a/tool/test/expect/haxe_4/node-debug-test12.json
+++ b/tool/test/expect/haxe_4/node-debug-test12.json
@@ -24,6 +24,10 @@
   {
     "isMain": false,
     "isLib": true,
+    "libParams": [
+      "lib_",
+      "a_$b_C_$_$d"
+    ],
     "name": "lib",
     "nodes": [
       "a_$b_C_$_$d",

--- a/tool/test/expect/haxe_4/node-debug-test12.json
+++ b/tool/test/expect/haxe_4/node-debug-test12.json
@@ -29,6 +29,7 @@
       "a_$b_C_$_$d"
     ],
     "name": "lib",
+    "alias": "lib",
     "nodes": [
       "a_$b_C_$_$d",
       "lib_DepLib",

--- a/tool/test/expect/haxe_4/node-debug-test13.json
+++ b/tool/test/expect/haxe_4/node-debug-test13.json
@@ -19,6 +19,7 @@
     "isMain": false,
     "isLib": false,
     "name": "a_$b_Exposed",
+    "alias": "a_$b_Exposed",
     "nodes": [
       "a_$b_Exposed",
       "a_$b_SubExposed"

--- a/tool/test/expect/haxe_4/node-debug-test14.json
+++ b/tool/test/expect/haxe_4/node-debug-test14.json
@@ -16,6 +16,7 @@
     "isMain": false,
     "isLib": false,
     "name": "a_$b_Exposed",
+    "alias": "a_$b_Exposed",
     "nodes": [
       "a_$b_Exposed",
       "a_$b_SubExposed"

--- a/tool/test/expect/haxe_4/node-debug-test15.json
+++ b/tool/test/expect/haxe_4/node-debug-test15.json
@@ -21,6 +21,7 @@
     "isMain": false,
     "isLib": false,
     "name": "CaseG",
+    "alias": "CaseG",
     "nodes": [
       "CaseG"
     ],

--- a/tool/test/expect/haxe_4/node-debug-test2.json
+++ b/tool/test/expect/haxe_4/node-debug-test2.json
@@ -30,6 +30,7 @@
     "isMain": false,
     "isLib": false,
     "name": "CaseA",
+    "alias": "CaseA",
     "nodes": [
       "CaseA"
     ],
@@ -46,6 +47,7 @@
     "isMain": false,
     "isLib": false,
     "name": "CaseB",
+    "alias": "CaseB",
     "nodes": [
       "CaseB",
       "DepB"

--- a/tool/test/expect/haxe_4/node-debug-test3.json
+++ b/tool/test/expect/haxe_4/node-debug-test3.json
@@ -22,6 +22,7 @@
     "isMain": false,
     "isLib": false,
     "name": "CaseC",
+    "alias": "CaseC",
     "nodes": [
       "CaseC"
     ],
@@ -39,6 +40,7 @@
     "isMain": false,
     "isLib": false,
     "name": "DepC",
+    "alias": "DepC",
     "nodes": [
       "DepC",
       "DepSubC"
@@ -60,6 +62,7 @@
     "isMain": false,
     "isLib": false,
     "name": "SubC",
+    "alias": "SubC",
     "nodes": [
       "SubC"
     ],
@@ -76,6 +79,7 @@
     "isMain": false,
     "isLib": false,
     "name": "SubC2",
+    "alias": "SubC2",
     "nodes": [
       "SubC2"
     ],

--- a/tool/test/expect/haxe_4/node-debug-test4.json
+++ b/tool/test/expect/haxe_4/node-debug-test4.json
@@ -33,24 +33,6 @@
   },
   {
     "isMain": false,
-    "isLib": true,
-    "name": "lib",
-    "nodes": [
-      "lib_DepLib",
-      "lib_Lib",
-      "lib_Lib2"
-    ],
-    "exports": {
-      "lib_Lib": true,
-      "lib_Lib2": true
-    },
-    "shared": {},
-    "imports": {
-      "$hxClasses": true
-    }
-  },
-  {
-    "isMain": false,
     "isLib": false,
     "name": "CaseA",
     "nodes": [
@@ -83,6 +65,27 @@
       "DepDepB": true,
       "$hxClasses": true,
       "lib_Lib2": true
+    }
+  },
+  {
+    "isMain": false,
+    "isLib": true,
+    "libParams": [
+      "lib_"
+    ],
+    "name": "lib",
+    "nodes": [
+      "lib_DepLib",
+      "lib_Lib",
+      "lib_Lib2"
+    ],
+    "exports": {
+      "lib_Lib": true,
+      "lib_Lib2": true
+    },
+    "shared": {},
+    "imports": {
+      "$hxClasses": true
     }
   }
 ]

--- a/tool/test/expect/haxe_4/node-debug-test4.json
+++ b/tool/test/expect/haxe_4/node-debug-test4.json
@@ -35,6 +35,7 @@
     "isMain": false,
     "isLib": false,
     "name": "CaseA",
+    "alias": "CaseA",
     "nodes": [
       "CaseA"
     ],
@@ -52,6 +53,7 @@
     "isMain": false,
     "isLib": false,
     "name": "CaseB",
+    "alias": "CaseB",
     "nodes": [
       "CaseB",
       "DepB"
@@ -74,6 +76,7 @@
       "lib_"
     ],
     "name": "lib",
+    "alias": "lib",
     "nodes": [
       "lib_DepLib",
       "lib_Lib",

--- a/tool/test/expect/haxe_4/node-debug-test5.json
+++ b/tool/test/expect/haxe_4/node-debug-test5.json
@@ -37,6 +37,7 @@
     "isMain": false,
     "isLib": false,
     "name": "CaseA",
+    "alias": "CaseA",
     "nodes": [
       "CaseA"
     ],
@@ -54,6 +55,7 @@
     "isMain": false,
     "isLib": false,
     "name": "CaseB",
+    "alias": "CaseB",
     "nodes": [
       "CaseB",
       "DepB"
@@ -77,6 +79,7 @@
       "a_$b_C_$_$d"
     ],
     "name": "lib",
+    "alias": "lib",
     "nodes": [
       "a_$b_C_$_$d",
       "lib_DepLib",

--- a/tool/test/expect/haxe_4/node-debug-test5.json
+++ b/tool/test/expect/haxe_4/node-debug-test5.json
@@ -35,26 +35,6 @@
   },
   {
     "isMain": false,
-    "isLib": true,
-    "name": "lib",
-    "nodes": [
-      "a_$b_C_$_$d",
-      "lib_DepLib",
-      "lib_Lib",
-      "lib_Lib2"
-    ],
-    "exports": {
-      "lib_Lib2": true,
-      "a_$b_C_$_$d": true,
-      "lib_Lib": true
-    },
-    "shared": {},
-    "imports": {
-      "$hxClasses": true
-    }
-  },
-  {
-    "isMain": false,
     "isLib": false,
     "name": "CaseA",
     "nodes": [
@@ -87,6 +67,30 @@
       "DepDepB": true,
       "$hxClasses": true,
       "lib_Lib2": true
+    }
+  },
+  {
+    "isMain": false,
+    "isLib": true,
+    "libParams": [
+      "lib_",
+      "a_$b_C_$_$d"
+    ],
+    "name": "lib",
+    "nodes": [
+      "a_$b_C_$_$d",
+      "lib_DepLib",
+      "lib_Lib",
+      "lib_Lib2"
+    ],
+    "exports": {
+      "lib_Lib2": true,
+      "a_$b_C_$_$d": true,
+      "lib_Lib": true
+    },
+    "shared": {},
+    "imports": {
+      "$hxClasses": true
     }
   }
 ]

--- a/tool/test/expect/haxe_4/node-debug-test6.json
+++ b/tool/test/expect/haxe_4/node-debug-test6.json
@@ -21,6 +21,7 @@
     "isMain": false,
     "isLib": false,
     "name": "CaseA",
+    "alias": "CaseA",
     "nodes": [
       "CaseA",
       "DepAB",

--- a/tool/test/expect/haxe_4/node-debug-test7.json
+++ b/tool/test/expect/haxe_4/node-debug-test7.json
@@ -19,6 +19,7 @@
     "isMain": false,
     "isLib": false,
     "name": "CaseD",
+    "alias": "CaseD",
     "nodes": [
       "CaseD",
       "CycleD"

--- a/tool/test/expect/haxe_4/node-debug-test9.json
+++ b/tool/test/expect/haxe_4/node-debug-test9.json
@@ -19,6 +19,7 @@
     "isMain": false,
     "isLib": false,
     "name": "CaseD",
+    "alias": "CaseD",
     "nodes": [
       "CaseD"
     ],

--- a/tool/test/expect/haxe_4/node-release-test1.json
+++ b/tool/test/expect/haxe_4/node-release-test1.json
@@ -30,6 +30,7 @@
     "isMain": false,
     "isLib": false,
     "name": "CaseA",
+    "alias": "CaseA",
     "nodes": [
       "CaseA"
     ],
@@ -46,6 +47,7 @@
     "isMain": false,
     "isLib": false,
     "name": "CaseB",
+    "alias": "CaseB",
     "nodes": [
       "CaseB",
       "DepB",

--- a/tool/test/expect/haxe_4/node-release-test10.json
+++ b/tool/test/expect/haxe_4/node-release-test10.json
@@ -21,6 +21,7 @@
     "isMain": false,
     "isLib": false,
     "name": "CaseE",
+    "alias": "CaseE",
     "nodes": [
       "CaseE"
     ],
@@ -39,6 +40,7 @@
     "isMain": false,
     "isLib": false,
     "name": "DepE",
+    "alias": "DepE",
     "nodes": [
       "DepE"
     ],

--- a/tool/test/expect/haxe_4/node-release-test11.json
+++ b/tool/test/expect/haxe_4/node-release-test11.json
@@ -19,6 +19,7 @@
     "isMain": false,
     "isLib": false,
     "name": "CaseF",
+    "alias": "CaseF",
     "nodes": [
       "$extend",
       "CaseF",

--- a/tool/test/expect/haxe_4/node-release-test12.json
+++ b/tool/test/expect/haxe_4/node-release-test12.json
@@ -24,6 +24,10 @@
   {
     "isMain": false,
     "isLib": true,
+    "libParams": [
+      "lib_",
+      "a_$b_C_$_$d"
+    ],
     "name": "lib",
     "nodes": [
       "a_$b_C_$_$d",

--- a/tool/test/expect/haxe_4/node-release-test12.json
+++ b/tool/test/expect/haxe_4/node-release-test12.json
@@ -29,6 +29,7 @@
       "a_$b_C_$_$d"
     ],
     "name": "lib",
+    "alias": "lib",
     "nodes": [
       "a_$b_C_$_$d",
       "lib_DepLib",

--- a/tool/test/expect/haxe_4/node-release-test13.json
+++ b/tool/test/expect/haxe_4/node-release-test13.json
@@ -19,6 +19,7 @@
     "isMain": false,
     "isLib": false,
     "name": "a_$b_Exposed",
+    "alias": "a_$b_Exposed",
     "nodes": [
       "a_$b_Exposed",
       "a_$b_SubExposed"

--- a/tool/test/expect/haxe_4/node-release-test14.json
+++ b/tool/test/expect/haxe_4/node-release-test14.json
@@ -16,6 +16,7 @@
     "isMain": false,
     "isLib": false,
     "name": "a_$b_Exposed",
+    "alias": "a_$b_Exposed",
     "nodes": [
       "a_$b_Exposed",
       "a_$b_SubExposed"

--- a/tool/test/expect/haxe_4/node-release-test15.json
+++ b/tool/test/expect/haxe_4/node-release-test15.json
@@ -21,6 +21,7 @@
     "isMain": false,
     "isLib": false,
     "name": "CaseG",
+    "alias": "CaseG",
     "nodes": [
       "CaseG"
     ],

--- a/tool/test/expect/haxe_4/node-release-test2.json
+++ b/tool/test/expect/haxe_4/node-release-test2.json
@@ -30,6 +30,7 @@
     "isMain": false,
     "isLib": false,
     "name": "CaseA",
+    "alias": "CaseA",
     "nodes": [
       "CaseA"
     ],
@@ -46,6 +47,7 @@
     "isMain": false,
     "isLib": false,
     "name": "CaseB",
+    "alias": "CaseB",
     "nodes": [
       "CaseB",
       "DepB",

--- a/tool/test/expect/haxe_4/node-release-test3.json
+++ b/tool/test/expect/haxe_4/node-release-test3.json
@@ -22,6 +22,7 @@
     "isMain": false,
     "isLib": false,
     "name": "CaseC",
+    "alias": "CaseC",
     "nodes": [
       "CaseC"
     ],
@@ -39,6 +40,7 @@
     "isMain": false,
     "isLib": false,
     "name": "DepC",
+    "alias": "DepC",
     "nodes": [
       "DepC",
       "DepSubC"
@@ -60,6 +62,7 @@
     "isMain": false,
     "isLib": false,
     "name": "SubC",
+    "alias": "SubC",
     "nodes": [
       "SubC"
     ],
@@ -76,6 +79,7 @@
     "isMain": false,
     "isLib": false,
     "name": "SubC2",
+    "alias": "SubC2",
     "nodes": [
       "SubC2"
     ],

--- a/tool/test/expect/haxe_4/node-release-test4.json
+++ b/tool/test/expect/haxe_4/node-release-test4.json
@@ -35,6 +35,7 @@
     "isMain": false,
     "isLib": false,
     "name": "CaseA",
+    "alias": "CaseA",
     "nodes": [
       "CaseA"
     ],
@@ -52,6 +53,7 @@
     "isMain": false,
     "isLib": false,
     "name": "CaseB",
+    "alias": "CaseB",
     "nodes": [
       "CaseB",
       "DepB",
@@ -76,6 +78,7 @@
       "lib_"
     ],
     "name": "lib",
+    "alias": "lib",
     "nodes": [
       "lib_DepLib",
       "lib_Lib",

--- a/tool/test/expect/haxe_4/node-release-test4.json
+++ b/tool/test/expect/haxe_4/node-release-test4.json
@@ -33,24 +33,6 @@
   },
   {
     "isMain": false,
-    "isLib": true,
-    "name": "lib",
-    "nodes": [
-      "lib_DepLib",
-      "lib_Lib",
-      "lib_Lib2"
-    ],
-    "exports": {
-      "lib_Lib": true,
-      "lib_Lib2": true
-    },
-    "shared": {},
-    "imports": {
-      "$hxClasses": true
-    }
-  },
-  {
-    "isMain": false,
     "isLib": false,
     "name": "CaseA",
     "nodes": [
@@ -85,6 +67,27 @@
       "$hxEnums": true,
       "$hxClasses": true,
       "lib_Lib2": true
+    }
+  },
+  {
+    "isMain": false,
+    "isLib": true,
+    "libParams": [
+      "lib_"
+    ],
+    "name": "lib",
+    "nodes": [
+      "lib_DepLib",
+      "lib_Lib",
+      "lib_Lib2"
+    ],
+    "exports": {
+      "lib_Lib": true,
+      "lib_Lib2": true
+    },
+    "shared": {},
+    "imports": {
+      "$hxClasses": true
     }
   }
 ]

--- a/tool/test/expect/haxe_4/node-release-test5.json
+++ b/tool/test/expect/haxe_4/node-release-test5.json
@@ -37,6 +37,7 @@
     "isMain": false,
     "isLib": false,
     "name": "CaseA",
+    "alias": "CaseA",
     "nodes": [
       "CaseA"
     ],
@@ -54,6 +55,7 @@
     "isMain": false,
     "isLib": false,
     "name": "CaseB",
+    "alias": "CaseB",
     "nodes": [
       "CaseB",
       "DepB",
@@ -79,6 +81,7 @@
       "a_$b_C_$_$d"
     ],
     "name": "lib",
+    "alias": "lib",
     "nodes": [
       "a_$b_C_$_$d",
       "lib_DepLib",

--- a/tool/test/expect/haxe_4/node-release-test5.json
+++ b/tool/test/expect/haxe_4/node-release-test5.json
@@ -35,26 +35,6 @@
   },
   {
     "isMain": false,
-    "isLib": true,
-    "name": "lib",
-    "nodes": [
-      "a_$b_C_$_$d",
-      "lib_DepLib",
-      "lib_Lib",
-      "lib_Lib2"
-    ],
-    "exports": {
-      "lib_Lib2": true,
-      "a_$b_C_$_$d": true,
-      "lib_Lib": true
-    },
-    "shared": {},
-    "imports": {
-      "$hxClasses": true
-    }
-  },
-  {
-    "isMain": false,
     "isLib": false,
     "name": "CaseA",
     "nodes": [
@@ -89,6 +69,30 @@
       "$hxEnums": true,
       "$hxClasses": true,
       "lib_Lib2": true
+    }
+  },
+  {
+    "isMain": false,
+    "isLib": true,
+    "libParams": [
+      "lib_",
+      "a_$b_C_$_$d"
+    ],
+    "name": "lib",
+    "nodes": [
+      "a_$b_C_$_$d",
+      "lib_DepLib",
+      "lib_Lib",
+      "lib_Lib2"
+    ],
+    "exports": {
+      "lib_Lib2": true,
+      "a_$b_C_$_$d": true,
+      "lib_Lib": true
+    },
+    "shared": {},
+    "imports": {
+      "$hxClasses": true
     }
   }
 ]

--- a/tool/test/expect/haxe_4/node-release-test6.json
+++ b/tool/test/expect/haxe_4/node-release-test6.json
@@ -21,6 +21,7 @@
     "isMain": false,
     "isLib": false,
     "name": "CaseA",
+    "alias": "CaseA",
     "nodes": [
       "CaseA",
       "DepAB",

--- a/tool/test/expect/haxe_4/node-release-test7.json
+++ b/tool/test/expect/haxe_4/node-release-test7.json
@@ -19,6 +19,7 @@
     "isMain": false,
     "isLib": false,
     "name": "CaseD",
+    "alias": "CaseD",
     "nodes": [
       "CaseD",
       "CycleD"

--- a/tool/test/expect/haxe_4/node-release-test9.json
+++ b/tool/test/expect/haxe_4/node-release-test9.json
@@ -19,6 +19,7 @@
     "isMain": false,
     "isLib": false,
     "name": "CaseD",
+    "alias": "CaseD",
     "nodes": [
       "CaseD"
     ],

--- a/tool/test/expect/haxe_4/web-debug-closure-testinterop.json
+++ b/tool/test/expect/haxe_4/web-debug-closure-testinterop.json
@@ -37,6 +37,7 @@
     "isMain": false,
     "isLib": false,
     "name": "CaseInterop",
+    "alias": "CaseInterop",
     "nodes": [
       "CaseInterop"
     ],
@@ -58,6 +59,7 @@
     "isMain": false,
     "isLib": false,
     "name": "a_$b_C_$_$d",
+    "alias": "a_$b_C_$_$d",
     "nodes": [
       "a_$b_C_$_$d"
     ],

--- a/tool/test/expect/haxe_4/web-debug-test1.json
+++ b/tool/test/expect/haxe_4/web-debug-test1.json
@@ -36,6 +36,7 @@
     "isMain": false,
     "isLib": false,
     "name": "CaseA",
+    "alias": "CaseA",
     "nodes": [
       "CaseA"
     ],
@@ -52,6 +53,7 @@
     "isMain": false,
     "isLib": false,
     "name": "CaseB",
+    "alias": "CaseB",
     "nodes": [
       "CaseB",
       "DepB"

--- a/tool/test/expect/haxe_4/web-debug-test10.json
+++ b/tool/test/expect/haxe_4/web-debug-test10.json
@@ -31,6 +31,7 @@
     "isMain": false,
     "isLib": false,
     "name": "CaseE",
+    "alias": "CaseE",
     "nodes": [
       "CaseE"
     ],
@@ -50,6 +51,7 @@
     "isMain": false,
     "isLib": false,
     "name": "DepE",
+    "alias": "DepE",
     "nodes": [
       "DepE"
     ],

--- a/tool/test/expect/haxe_4/web-debug-test11.json
+++ b/tool/test/expect/haxe_4/web-debug-test11.json
@@ -29,6 +29,7 @@
     "isMain": false,
     "isLib": false,
     "name": "CaseF",
+    "alias": "CaseF",
     "nodes": [
       "CaseF"
     ],

--- a/tool/test/expect/haxe_4/web-debug-test12.json
+++ b/tool/test/expect/haxe_4/web-debug-test12.json
@@ -30,6 +30,7 @@
       "a_$b_C_$_$d"
     ],
     "name": "lib",
+    "alias": "lib",
     "nodes": [
       "a_$b_C_$_$d",
       "lib_DepLib",

--- a/tool/test/expect/haxe_4/web-debug-test12.json
+++ b/tool/test/expect/haxe_4/web-debug-test12.json
@@ -25,6 +25,10 @@
   {
     "isMain": false,
     "isLib": true,
+    "libParams": [
+      "lib_",
+      "a_$b_C_$_$d"
+    ],
     "name": "lib",
     "nodes": [
       "a_$b_C_$_$d",

--- a/tool/test/expect/haxe_4/web-debug-test13.json
+++ b/tool/test/expect/haxe_4/web-debug-test13.json
@@ -28,6 +28,7 @@
     "isMain": false,
     "isLib": false,
     "name": "a_$b_Exposed",
+    "alias": "a_$b_Exposed",
     "nodes": [
       "a_$b_Exposed",
       "a_$b_SubExposed"

--- a/tool/test/expect/haxe_4/web-debug-test14.json
+++ b/tool/test/expect/haxe_4/web-debug-test14.json
@@ -24,6 +24,7 @@
     "isMain": false,
     "isLib": false,
     "name": "a_$b_Exposed",
+    "alias": "a_$b_Exposed",
     "nodes": [
       "a_$b_Exposed",
       "a_$b_SubExposed"

--- a/tool/test/expect/haxe_4/web-debug-test15.json
+++ b/tool/test/expect/haxe_4/web-debug-test15.json
@@ -29,6 +29,7 @@
     "isMain": false,
     "isLib": false,
     "name": "CaseG",
+    "alias": "CaseG",
     "nodes": [
       "CaseG"
     ],

--- a/tool/test/expect/haxe_4/web-debug-test2.json
+++ b/tool/test/expect/haxe_4/web-debug-test2.json
@@ -36,6 +36,7 @@
     "isMain": false,
     "isLib": false,
     "name": "CaseA",
+    "alias": "CaseA",
     "nodes": [
       "CaseA"
     ],
@@ -52,6 +53,7 @@
     "isMain": false,
     "isLib": false,
     "name": "CaseB",
+    "alias": "CaseB",
     "nodes": [
       "CaseB",
       "DepB"

--- a/tool/test/expect/haxe_4/web-debug-test3.json
+++ b/tool/test/expect/haxe_4/web-debug-test3.json
@@ -32,6 +32,7 @@
     "isMain": false,
     "isLib": false,
     "name": "CaseC",
+    "alias": "CaseC",
     "nodes": [
       "CaseC"
     ],
@@ -50,6 +51,7 @@
     "isMain": false,
     "isLib": false,
     "name": "DepC",
+    "alias": "DepC",
     "nodes": [
       "DepC",
       "DepSubC"
@@ -72,6 +74,7 @@
     "isMain": false,
     "isLib": false,
     "name": "SubC",
+    "alias": "SubC",
     "nodes": [
       "SubC"
     ],
@@ -88,6 +91,7 @@
     "isMain": false,
     "isLib": false,
     "name": "SubC2",
+    "alias": "SubC2",
     "nodes": [
       "SubC2"
     ],

--- a/tool/test/expect/haxe_4/web-debug-test4.json
+++ b/tool/test/expect/haxe_4/web-debug-test4.json
@@ -38,6 +38,7 @@
     "isMain": false,
     "isLib": false,
     "name": "CaseA",
+    "alias": "CaseA",
     "nodes": [
       "CaseA"
     ],
@@ -55,6 +56,7 @@
     "isMain": false,
     "isLib": false,
     "name": "CaseB",
+    "alias": "CaseB",
     "nodes": [
       "CaseB",
       "DepB"
@@ -77,6 +79,7 @@
       "lib_"
     ],
     "name": "lib",
+    "alias": "lib",
     "nodes": [
       "lib_DepLib",
       "lib_Lib",

--- a/tool/test/expect/haxe_4/web-debug-test4.json
+++ b/tool/test/expect/haxe_4/web-debug-test4.json
@@ -36,24 +36,6 @@
   },
   {
     "isMain": false,
-    "isLib": true,
-    "name": "lib",
-    "nodes": [
-      "lib_DepLib",
-      "lib_Lib",
-      "lib_Lib2"
-    ],
-    "exports": {
-      "lib_Lib": true,
-      "lib_Lib2": true
-    },
-    "shared": {},
-    "imports": {
-      "$hxClasses": true
-    }
-  },
-  {
-    "isMain": false,
     "isLib": false,
     "name": "CaseA",
     "nodes": [
@@ -86,6 +68,27 @@
       "DepDepB": true,
       "$hxClasses": true,
       "lib_Lib2": true
+    }
+  },
+  {
+    "isMain": false,
+    "isLib": true,
+    "libParams": [
+      "lib_"
+    ],
+    "name": "lib",
+    "nodes": [
+      "lib_DepLib",
+      "lib_Lib",
+      "lib_Lib2"
+    ],
+    "exports": {
+      "lib_Lib": true,
+      "lib_Lib2": true
+    },
+    "shared": {},
+    "imports": {
+      "$hxClasses": true
     }
   }
 ]

--- a/tool/test/expect/haxe_4/web-debug-test5.json
+++ b/tool/test/expect/haxe_4/web-debug-test5.json
@@ -38,26 +38,6 @@
   },
   {
     "isMain": false,
-    "isLib": true,
-    "name": "lib",
-    "nodes": [
-      "a_$b_C_$_$d",
-      "lib_DepLib",
-      "lib_Lib",
-      "lib_Lib2"
-    ],
-    "exports": {
-      "lib_Lib2": true,
-      "a_$b_C_$_$d": true,
-      "lib_Lib": true
-    },
-    "shared": {},
-    "imports": {
-      "$hxClasses": true
-    }
-  },
-  {
-    "isMain": false,
     "isLib": false,
     "name": "CaseA",
     "nodes": [
@@ -90,6 +70,30 @@
       "DepDepB": true,
       "$hxClasses": true,
       "lib_Lib2": true
+    }
+  },
+  {
+    "isMain": false,
+    "isLib": true,
+    "libParams": [
+      "lib_",
+      "a_$b_C_$_$d"
+    ],
+    "name": "lib",
+    "nodes": [
+      "a_$b_C_$_$d",
+      "lib_DepLib",
+      "lib_Lib",
+      "lib_Lib2"
+    ],
+    "exports": {
+      "lib_Lib2": true,
+      "a_$b_C_$_$d": true,
+      "lib_Lib": true
+    },
+    "shared": {},
+    "imports": {
+      "$hxClasses": true
     }
   }
 ]

--- a/tool/test/expect/haxe_4/web-debug-test5.json
+++ b/tool/test/expect/haxe_4/web-debug-test5.json
@@ -40,6 +40,7 @@
     "isMain": false,
     "isLib": false,
     "name": "CaseA",
+    "alias": "CaseA",
     "nodes": [
       "CaseA"
     ],
@@ -57,6 +58,7 @@
     "isMain": false,
     "isLib": false,
     "name": "CaseB",
+    "alias": "CaseB",
     "nodes": [
       "CaseB",
       "DepB"
@@ -80,6 +82,7 @@
       "a_$b_C_$_$d"
     ],
     "name": "lib",
+    "alias": "lib",
     "nodes": [
       "a_$b_C_$_$d",
       "lib_DepLib",

--- a/tool/test/expect/haxe_4/web-debug-test6.json
+++ b/tool/test/expect/haxe_4/web-debug-test6.json
@@ -30,6 +30,7 @@
     "isMain": false,
     "isLib": false,
     "name": "CaseA",
+    "alias": "CaseA",
     "nodes": [
       "CaseA",
       "DepAB",

--- a/tool/test/expect/haxe_4/web-debug-test7.json
+++ b/tool/test/expect/haxe_4/web-debug-test7.json
@@ -28,6 +28,7 @@
     "isMain": false,
     "isLib": false,
     "name": "CaseD",
+    "alias": "CaseD",
     "nodes": [
       "CaseD",
       "CycleD"

--- a/tool/test/expect/haxe_4/web-debug-test9.json
+++ b/tool/test/expect/haxe_4/web-debug-test9.json
@@ -28,6 +28,7 @@
     "isMain": false,
     "isLib": false,
     "name": "CaseD",
+    "alias": "CaseD",
     "nodes": [
       "CaseD"
     ],

--- a/tool/test/expect/haxe_4/web-debug-testinterop.json
+++ b/tool/test/expect/haxe_4/web-debug-testinterop.json
@@ -37,6 +37,7 @@
     "isMain": false,
     "isLib": false,
     "name": "CaseInterop",
+    "alias": "CaseInterop",
     "nodes": [
       "CaseInterop"
     ],
@@ -58,6 +59,7 @@
     "isMain": false,
     "isLib": false,
     "name": "a_$b_C_$_$d",
+    "alias": "a_$b_C_$_$d",
     "nodes": [
       "a_$b_C_$_$d"
     ],

--- a/tool/test/expect/haxe_4/web-debug-uglify-testinterop.json
+++ b/tool/test/expect/haxe_4/web-debug-uglify-testinterop.json
@@ -37,6 +37,7 @@
     "isMain": false,
     "isLib": false,
     "name": "CaseInterop",
+    "alias": "CaseInterop",
     "nodes": [
       "CaseInterop"
     ],
@@ -58,6 +59,7 @@
     "isMain": false,
     "isLib": false,
     "name": "a_$b_C_$_$d",
+    "alias": "a_$b_C_$_$d",
     "nodes": [
       "a_$b_C_$_$d"
     ],

--- a/tool/test/expect/haxe_4/web-release-closure-testinterop.json
+++ b/tool/test/expect/haxe_4/web-release-closure-testinterop.json
@@ -36,6 +36,7 @@
     "isMain": false,
     "isLib": false,
     "name": "CaseInterop",
+    "alias": "CaseInterop",
     "nodes": [
       "CaseInterop"
     ],
@@ -57,6 +58,7 @@
     "isMain": false,
     "isLib": false,
     "name": "a_$b_C_$_$d",
+    "alias": "a_$b_C_$_$d",
     "nodes": [
       "a_$b_C_$_$d"
     ],

--- a/tool/test/expect/haxe_4/web-release-test1.json
+++ b/tool/test/expect/haxe_4/web-release-test1.json
@@ -34,6 +34,7 @@
     "isMain": false,
     "isLib": false,
     "name": "CaseA",
+    "alias": "CaseA",
     "nodes": [
       "CaseA"
     ],
@@ -50,6 +51,7 @@
     "isMain": false,
     "isLib": false,
     "name": "CaseB",
+    "alias": "CaseB",
     "nodes": [
       "CaseB",
       "DepB",

--- a/tool/test/expect/haxe_4/web-release-test10.json
+++ b/tool/test/expect/haxe_4/web-release-test10.json
@@ -26,6 +26,7 @@
     "isMain": false,
     "isLib": false,
     "name": "CaseE",
+    "alias": "CaseE",
     "nodes": [
       "CaseE"
     ],
@@ -45,6 +46,7 @@
     "isMain": false,
     "isLib": false,
     "name": "DepE",
+    "alias": "DepE",
     "nodes": [
       "DepE"
     ],

--- a/tool/test/expect/haxe_4/web-release-test11.json
+++ b/tool/test/expect/haxe_4/web-release-test11.json
@@ -23,6 +23,7 @@
     "isMain": false,
     "isLib": false,
     "name": "CaseF",
+    "alias": "CaseF",
     "nodes": [
       "$extend",
       "CaseF",

--- a/tool/test/expect/haxe_4/web-release-test12.json
+++ b/tool/test/expect/haxe_4/web-release-test12.json
@@ -30,6 +30,7 @@
       "a_$b_C_$_$d"
     ],
     "name": "lib",
+    "alias": "lib",
     "nodes": [
       "a_$b_C_$_$d",
       "lib_DepLib",

--- a/tool/test/expect/haxe_4/web-release-test12.json
+++ b/tool/test/expect/haxe_4/web-release-test12.json
@@ -25,6 +25,10 @@
   {
     "isMain": false,
     "isLib": true,
+    "libParams": [
+      "lib_",
+      "a_$b_C_$_$d"
+    ],
     "name": "lib",
     "nodes": [
       "a_$b_C_$_$d",

--- a/tool/test/expect/haxe_4/web-release-test13.json
+++ b/tool/test/expect/haxe_4/web-release-test13.json
@@ -23,6 +23,7 @@
     "isMain": false,
     "isLib": false,
     "name": "a_$b_Exposed",
+    "alias": "a_$b_Exposed",
     "nodes": [
       "a_$b_Exposed",
       "a_$b_SubExposed"

--- a/tool/test/expect/haxe_4/web-release-test14.json
+++ b/tool/test/expect/haxe_4/web-release-test14.json
@@ -19,6 +19,7 @@
     "isMain": false,
     "isLib": false,
     "name": "a_$b_Exposed",
+    "alias": "a_$b_Exposed",
     "nodes": [
       "a_$b_Exposed",
       "a_$b_SubExposed"

--- a/tool/test/expect/haxe_4/web-release-test15.json
+++ b/tool/test/expect/haxe_4/web-release-test15.json
@@ -24,6 +24,7 @@
     "isMain": false,
     "isLib": false,
     "name": "CaseG",
+    "alias": "CaseG",
     "nodes": [
       "CaseG"
     ],

--- a/tool/test/expect/haxe_4/web-release-test2.json
+++ b/tool/test/expect/haxe_4/web-release-test2.json
@@ -34,6 +34,7 @@
     "isMain": false,
     "isLib": false,
     "name": "CaseA",
+    "alias": "CaseA",
     "nodes": [
       "CaseA"
     ],
@@ -50,6 +51,7 @@
     "isMain": false,
     "isLib": false,
     "name": "CaseB",
+    "alias": "CaseB",
     "nodes": [
       "CaseB",
       "DepB",

--- a/tool/test/expect/haxe_4/web-release-test3.json
+++ b/tool/test/expect/haxe_4/web-release-test3.json
@@ -27,6 +27,7 @@
     "isMain": false,
     "isLib": false,
     "name": "CaseC",
+    "alias": "CaseC",
     "nodes": [
       "CaseC"
     ],
@@ -45,6 +46,7 @@
     "isMain": false,
     "isLib": false,
     "name": "DepC",
+    "alias": "DepC",
     "nodes": [
       "DepC",
       "DepSubC"
@@ -67,6 +69,7 @@
     "isMain": false,
     "isLib": false,
     "name": "SubC",
+    "alias": "SubC",
     "nodes": [
       "SubC"
     ],
@@ -83,6 +86,7 @@
     "isMain": false,
     "isLib": false,
     "name": "SubC2",
+    "alias": "SubC2",
     "nodes": [
       "SubC2"
     ],

--- a/tool/test/expect/haxe_4/web-release-test4.json
+++ b/tool/test/expect/haxe_4/web-release-test4.json
@@ -36,6 +36,7 @@
     "isMain": false,
     "isLib": false,
     "name": "CaseA",
+    "alias": "CaseA",
     "nodes": [
       "CaseA"
     ],
@@ -53,6 +54,7 @@
     "isMain": false,
     "isLib": false,
     "name": "CaseB",
+    "alias": "CaseB",
     "nodes": [
       "CaseB",
       "DepB",
@@ -77,6 +79,7 @@
       "lib_"
     ],
     "name": "lib",
+    "alias": "lib",
     "nodes": [
       "lib_DepLib",
       "lib_Lib",

--- a/tool/test/expect/haxe_4/web-release-test4.json
+++ b/tool/test/expect/haxe_4/web-release-test4.json
@@ -34,24 +34,6 @@
   },
   {
     "isMain": false,
-    "isLib": true,
-    "name": "lib",
-    "nodes": [
-      "lib_DepLib",
-      "lib_Lib",
-      "lib_Lib2"
-    ],
-    "exports": {
-      "lib_Lib": true,
-      "lib_Lib2": true
-    },
-    "shared": {},
-    "imports": {
-      "$hxClasses": true
-    }
-  },
-  {
-    "isMain": false,
     "isLib": false,
     "name": "CaseA",
     "nodes": [
@@ -86,6 +68,27 @@
       "$hxEnums": true,
       "$hxClasses": true,
       "lib_Lib2": true
+    }
+  },
+  {
+    "isMain": false,
+    "isLib": true,
+    "libParams": [
+      "lib_"
+    ],
+    "name": "lib",
+    "nodes": [
+      "lib_DepLib",
+      "lib_Lib",
+      "lib_Lib2"
+    ],
+    "exports": {
+      "lib_Lib": true,
+      "lib_Lib2": true
+    },
+    "shared": {},
+    "imports": {
+      "$hxClasses": true
     }
   }
 ]

--- a/tool/test/expect/haxe_4/web-release-test5.json
+++ b/tool/test/expect/haxe_4/web-release-test5.json
@@ -38,6 +38,7 @@
     "isMain": false,
     "isLib": false,
     "name": "CaseA",
+    "alias": "CaseA",
     "nodes": [
       "CaseA"
     ],
@@ -55,6 +56,7 @@
     "isMain": false,
     "isLib": false,
     "name": "CaseB",
+    "alias": "CaseB",
     "nodes": [
       "CaseB",
       "DepB",
@@ -80,6 +82,7 @@
       "a_$b_C_$_$d"
     ],
     "name": "lib",
+    "alias": "lib",
     "nodes": [
       "a_$b_C_$_$d",
       "lib_DepLib",

--- a/tool/test/expect/haxe_4/web-release-test5.json
+++ b/tool/test/expect/haxe_4/web-release-test5.json
@@ -36,26 +36,6 @@
   },
   {
     "isMain": false,
-    "isLib": true,
-    "name": "lib",
-    "nodes": [
-      "a_$b_C_$_$d",
-      "lib_DepLib",
-      "lib_Lib",
-      "lib_Lib2"
-    ],
-    "exports": {
-      "lib_Lib2": true,
-      "a_$b_C_$_$d": true,
-      "lib_Lib": true
-    },
-    "shared": {},
-    "imports": {
-      "$hxClasses": true
-    }
-  },
-  {
-    "isMain": false,
     "isLib": false,
     "name": "CaseA",
     "nodes": [
@@ -90,6 +70,30 @@
       "$hxEnums": true,
       "$hxClasses": true,
       "lib_Lib2": true
+    }
+  },
+  {
+    "isMain": false,
+    "isLib": true,
+    "libParams": [
+      "lib_",
+      "a_$b_C_$_$d"
+    ],
+    "name": "lib",
+    "nodes": [
+      "a_$b_C_$_$d",
+      "lib_DepLib",
+      "lib_Lib",
+      "lib_Lib2"
+    ],
+    "exports": {
+      "lib_Lib2": true,
+      "a_$b_C_$_$d": true,
+      "lib_Lib": true
+    },
+    "shared": {},
+    "imports": {
+      "$hxClasses": true
     }
   }
 ]

--- a/tool/test/expect/haxe_4/web-release-test6.json
+++ b/tool/test/expect/haxe_4/web-release-test6.json
@@ -25,6 +25,7 @@
     "isMain": false,
     "isLib": false,
     "name": "CaseA",
+    "alias": "CaseA",
     "nodes": [
       "CaseA",
       "DepAB",

--- a/tool/test/expect/haxe_4/web-release-test7.json
+++ b/tool/test/expect/haxe_4/web-release-test7.json
@@ -23,6 +23,7 @@
     "isMain": false,
     "isLib": false,
     "name": "CaseD",
+    "alias": "CaseD",
     "nodes": [
       "CaseD",
       "CycleD"

--- a/tool/test/expect/haxe_4/web-release-test9.json
+++ b/tool/test/expect/haxe_4/web-release-test9.json
@@ -23,6 +23,7 @@
     "isMain": false,
     "isLib": false,
     "name": "CaseD",
+    "alias": "CaseD",
     "nodes": [
       "CaseD"
     ],

--- a/tool/test/expect/haxe_4/web-release-testinterop.json
+++ b/tool/test/expect/haxe_4/web-release-testinterop.json
@@ -36,6 +36,7 @@
     "isMain": false,
     "isLib": false,
     "name": "CaseInterop",
+    "alias": "CaseInterop",
     "nodes": [
       "CaseInterop"
     ],
@@ -57,6 +58,7 @@
     "isMain": false,
     "isLib": false,
     "name": "a_$b_C_$_$d",
+    "alias": "a_$b_C_$_$d",
     "nodes": [
       "a_$b_C_$_$d"
     ],

--- a/tool/test/expect/haxe_4/web-release-uglify-testinterop.json
+++ b/tool/test/expect/haxe_4/web-release-uglify-testinterop.json
@@ -36,6 +36,7 @@
     "isMain": false,
     "isLib": false,
     "name": "CaseInterop",
+    "alias": "CaseInterop",
     "nodes": [
       "CaseInterop"
     ],
@@ -57,6 +58,7 @@
     "isMain": false,
     "isLib": false,
     "name": "a_$b_C_$_$d",
+    "alias": "a_$b_C_$_$d",
     "nodes": [
       "a_$b_C_$_$d"
     ],

--- a/tool/test/expect/haxe_4_1/node-debug-test1.json
+++ b/tool/test/expect/haxe_4_1/node-debug-test1.json
@@ -29,6 +29,7 @@
     "isMain": false,
     "isLib": false,
     "name": "CaseA",
+    "alias": "CaseA",
     "nodes": [
       "CaseA"
     ],
@@ -45,6 +46,7 @@
     "isMain": false,
     "isLib": false,
     "name": "CaseB",
+    "alias": "CaseB",
     "nodes": [
       "CaseB",
       "DepB"

--- a/tool/test/expect/haxe_4_1/node-debug-test10.json
+++ b/tool/test/expect/haxe_4_1/node-debug-test10.json
@@ -22,6 +22,7 @@
     "isMain": false,
     "isLib": false,
     "name": "CaseE",
+    "alias": "CaseE",
     "nodes": [
       "CaseE"
     ],
@@ -40,6 +41,7 @@
     "isMain": false,
     "isLib": false,
     "name": "DepE",
+    "alias": "DepE",
     "nodes": [
       "DepE"
     ],

--- a/tool/test/expect/haxe_4_1/node-debug-test11.json
+++ b/tool/test/expect/haxe_4_1/node-debug-test11.json
@@ -20,6 +20,7 @@
     "isMain": false,
     "isLib": false,
     "name": "CaseF",
+    "alias": "CaseF",
     "nodes": [
       "$extend",
       "CaseF",

--- a/tool/test/expect/haxe_4_1/node-debug-test12.json
+++ b/tool/test/expect/haxe_4_1/node-debug-test12.json
@@ -30,6 +30,7 @@
       "a_$b_C_$_$d"
     ],
     "name": "lib",
+    "alias": "lib",
     "nodes": [
       "a_$b_C_$_$d",
       "lib_DepLib",

--- a/tool/test/expect/haxe_4_1/node-debug-test12.json
+++ b/tool/test/expect/haxe_4_1/node-debug-test12.json
@@ -25,6 +25,10 @@
   {
     "isMain": false,
     "isLib": true,
+    "libParams": [
+      "lib_",
+      "a_$b_C_$_$d"
+    ],
     "name": "lib",
     "nodes": [
       "a_$b_C_$_$d",

--- a/tool/test/expect/haxe_4_1/node-debug-test13.json
+++ b/tool/test/expect/haxe_4_1/node-debug-test13.json
@@ -20,6 +20,7 @@
     "isMain": false,
     "isLib": false,
     "name": "a_$b_Exposed",
+    "alias": "a_$b_Exposed",
     "nodes": [
       "a_$b_Exposed",
       "a_$b_SubExposed"

--- a/tool/test/expect/haxe_4_1/node-debug-test14.json
+++ b/tool/test/expect/haxe_4_1/node-debug-test14.json
@@ -17,6 +17,7 @@
     "isMain": false,
     "isLib": false,
     "name": "a_$b_Exposed",
+    "alias": "a_$b_Exposed",
     "nodes": [
       "a_$b_Exposed",
       "a_$b_SubExposed"

--- a/tool/test/expect/haxe_4_1/node-debug-test15.json
+++ b/tool/test/expect/haxe_4_1/node-debug-test15.json
@@ -21,6 +21,7 @@
     "isMain": false,
     "isLib": false,
     "name": "CaseG",
+    "alias": "CaseG",
     "nodes": [
       "CaseG"
     ],

--- a/tool/test/expect/haxe_4_1/node-debug-test2.json
+++ b/tool/test/expect/haxe_4_1/node-debug-test2.json
@@ -29,6 +29,7 @@
     "isMain": false,
     "isLib": false,
     "name": "CaseA",
+    "alias": "CaseA",
     "nodes": [
       "CaseA"
     ],
@@ -45,6 +46,7 @@
     "isMain": false,
     "isLib": false,
     "name": "CaseB",
+    "alias": "CaseB",
     "nodes": [
       "CaseB",
       "DepB"

--- a/tool/test/expect/haxe_4_1/node-debug-test3.json
+++ b/tool/test/expect/haxe_4_1/node-debug-test3.json
@@ -23,6 +23,7 @@
     "isMain": false,
     "isLib": false,
     "name": "CaseC",
+    "alias": "CaseC",
     "nodes": [
       "CaseC"
     ],
@@ -40,6 +41,7 @@
     "isMain": false,
     "isLib": false,
     "name": "DepC",
+    "alias": "DepC",
     "nodes": [
       "DepC",
       "DepSubC"
@@ -61,6 +63,7 @@
     "isMain": false,
     "isLib": false,
     "name": "SubC",
+    "alias": "SubC",
     "nodes": [
       "SubC"
     ],
@@ -77,6 +80,7 @@
     "isMain": false,
     "isLib": false,
     "name": "SubC2",
+    "alias": "SubC2",
     "nodes": [
       "SubC2"
     ],

--- a/tool/test/expect/haxe_4_1/node-debug-test4.json
+++ b/tool/test/expect/haxe_4_1/node-debug-test4.json
@@ -69,6 +69,9 @@
   {
     "isMain": false,
     "isLib": true,
+    "libParams": [
+      "lib_"
+    ],
     "name": "lib",
     "nodes": [
       "lib_DepLib",

--- a/tool/test/expect/haxe_4_1/node-debug-test4.json
+++ b/tool/test/expect/haxe_4_1/node-debug-test4.json
@@ -34,6 +34,7 @@
     "isMain": false,
     "isLib": false,
     "name": "CaseA",
+    "alias": "CaseA",
     "nodes": [
       "CaseA"
     ],
@@ -51,6 +52,7 @@
     "isMain": false,
     "isLib": false,
     "name": "CaseB",
+    "alias": "CaseB",
     "nodes": [
       "CaseB",
       "DepB"
@@ -73,6 +75,7 @@
       "lib_"
     ],
     "name": "lib",
+    "alias": "lib",
     "nodes": [
       "lib_DepLib",
       "lib_Lib",

--- a/tool/test/expect/haxe_4_1/node-debug-test5.json
+++ b/tool/test/expect/haxe_4_1/node-debug-test5.json
@@ -36,6 +36,7 @@
     "isMain": false,
     "isLib": false,
     "name": "CaseA",
+    "alias": "CaseA",
     "nodes": [
       "CaseA"
     ],
@@ -53,6 +54,7 @@
     "isMain": false,
     "isLib": false,
     "name": "CaseB",
+    "alias": "CaseB",
     "nodes": [
       "CaseB",
       "DepB"
@@ -76,6 +78,7 @@
       "a_$b_C_$_$d"
     ],
     "name": "lib",
+    "alias": "lib",
     "nodes": [
       "a_$b_C_$_$d",
       "lib_DepLib",

--- a/tool/test/expect/haxe_4_1/node-debug-test5.json
+++ b/tool/test/expect/haxe_4_1/node-debug-test5.json
@@ -71,6 +71,10 @@
   {
     "isMain": false,
     "isLib": true,
+    "libParams": [
+      "lib_",
+      "a_$b_C_$_$d"
+    ],
     "name": "lib",
     "nodes": [
       "a_$b_C_$_$d",

--- a/tool/test/expect/haxe_4_1/node-debug-test6.json
+++ b/tool/test/expect/haxe_4_1/node-debug-test6.json
@@ -22,6 +22,7 @@
     "isMain": false,
     "isLib": false,
     "name": "CaseA",
+    "alias": "CaseA",
     "nodes": [
       "CaseA",
       "DepAB",

--- a/tool/test/expect/haxe_4_1/node-debug-test7.json
+++ b/tool/test/expect/haxe_4_1/node-debug-test7.json
@@ -20,6 +20,7 @@
     "isMain": false,
     "isLib": false,
     "name": "CaseD",
+    "alias": "CaseD",
     "nodes": [
       "CaseD",
       "CycleD"

--- a/tool/test/expect/haxe_4_1/node-debug-test9.json
+++ b/tool/test/expect/haxe_4_1/node-debug-test9.json
@@ -20,6 +20,7 @@
     "isMain": false,
     "isLib": false,
     "name": "CaseD",
+    "alias": "CaseD",
     "nodes": [
       "CaseD"
     ],

--- a/tool/test/expect/haxe_4_1/node-release-test1.json
+++ b/tool/test/expect/haxe_4_1/node-release-test1.json
@@ -29,6 +29,7 @@
     "isMain": false,
     "isLib": false,
     "name": "CaseA",
+    "alias": "CaseA",
     "nodes": [
       "CaseA"
     ],
@@ -45,6 +46,7 @@
     "isMain": false,
     "isLib": false,
     "name": "CaseB",
+    "alias": "CaseB",
     "nodes": [
       "CaseB",
       "DepB",

--- a/tool/test/expect/haxe_4_1/node-release-test10.json
+++ b/tool/test/expect/haxe_4_1/node-release-test10.json
@@ -22,6 +22,7 @@
     "isMain": false,
     "isLib": false,
     "name": "CaseE",
+    "alias": "CaseE",
     "nodes": [
       "CaseE"
     ],
@@ -40,6 +41,7 @@
     "isMain": false,
     "isLib": false,
     "name": "DepE",
+    "alias": "DepE",
     "nodes": [
       "DepE"
     ],

--- a/tool/test/expect/haxe_4_1/node-release-test11.json
+++ b/tool/test/expect/haxe_4_1/node-release-test11.json
@@ -20,6 +20,7 @@
     "isMain": false,
     "isLib": false,
     "name": "CaseF",
+    "alias": "CaseF",
     "nodes": [
       "$extend",
       "CaseF",

--- a/tool/test/expect/haxe_4_1/node-release-test12.json
+++ b/tool/test/expect/haxe_4_1/node-release-test12.json
@@ -30,6 +30,7 @@
       "a_$b_C_$_$d"
     ],
     "name": "lib",
+    "alias": "lib",
     "nodes": [
       "a_$b_C_$_$d",
       "lib_DepLib",

--- a/tool/test/expect/haxe_4_1/node-release-test12.json
+++ b/tool/test/expect/haxe_4_1/node-release-test12.json
@@ -25,6 +25,10 @@
   {
     "isMain": false,
     "isLib": true,
+    "libParams": [
+      "lib_",
+      "a_$b_C_$_$d"
+    ],
     "name": "lib",
     "nodes": [
       "a_$b_C_$_$d",

--- a/tool/test/expect/haxe_4_1/node-release-test13.json
+++ b/tool/test/expect/haxe_4_1/node-release-test13.json
@@ -20,6 +20,7 @@
     "isMain": false,
     "isLib": false,
     "name": "a_$b_Exposed",
+    "alias": "a_$b_Exposed",
     "nodes": [
       "a_$b_Exposed",
       "a_$b_SubExposed"

--- a/tool/test/expect/haxe_4_1/node-release-test14.json
+++ b/tool/test/expect/haxe_4_1/node-release-test14.json
@@ -17,6 +17,7 @@
     "isMain": false,
     "isLib": false,
     "name": "a_$b_Exposed",
+    "alias": "a_$b_Exposed",
     "nodes": [
       "a_$b_Exposed",
       "a_$b_SubExposed"

--- a/tool/test/expect/haxe_4_1/node-release-test15.json
+++ b/tool/test/expect/haxe_4_1/node-release-test15.json
@@ -21,6 +21,7 @@
     "isMain": false,
     "isLib": false,
     "name": "CaseG",
+    "alias": "CaseG",
     "nodes": [
       "CaseG"
     ],

--- a/tool/test/expect/haxe_4_1/node-release-test2.json
+++ b/tool/test/expect/haxe_4_1/node-release-test2.json
@@ -29,6 +29,7 @@
     "isMain": false,
     "isLib": false,
     "name": "CaseA",
+    "alias": "CaseA",
     "nodes": [
       "CaseA"
     ],
@@ -45,6 +46,7 @@
     "isMain": false,
     "isLib": false,
     "name": "CaseB",
+    "alias": "CaseB",
     "nodes": [
       "CaseB",
       "DepB",

--- a/tool/test/expect/haxe_4_1/node-release-test3.json
+++ b/tool/test/expect/haxe_4_1/node-release-test3.json
@@ -23,6 +23,7 @@
     "isMain": false,
     "isLib": false,
     "name": "CaseC",
+    "alias": "CaseC",
     "nodes": [
       "CaseC"
     ],
@@ -40,6 +41,7 @@
     "isMain": false,
     "isLib": false,
     "name": "DepC",
+    "alias": "DepC",
     "nodes": [
       "DepC",
       "DepSubC"
@@ -61,6 +63,7 @@
     "isMain": false,
     "isLib": false,
     "name": "SubC",
+    "alias": "SubC",
     "nodes": [
       "SubC"
     ],
@@ -77,6 +80,7 @@
     "isMain": false,
     "isLib": false,
     "name": "SubC2",
+    "alias": "SubC2",
     "nodes": [
       "SubC2"
     ],

--- a/tool/test/expect/haxe_4_1/node-release-test4.json
+++ b/tool/test/expect/haxe_4_1/node-release-test4.json
@@ -34,6 +34,7 @@
     "isMain": false,
     "isLib": false,
     "name": "CaseA",
+    "alias": "CaseA",
     "nodes": [
       "CaseA"
     ],
@@ -51,6 +52,7 @@
     "isMain": false,
     "isLib": false,
     "name": "CaseB",
+    "alias": "CaseB",
     "nodes": [
       "CaseB",
       "DepB",
@@ -75,6 +77,7 @@
       "lib_"
     ],
     "name": "lib",
+    "alias": "lib",
     "nodes": [
       "lib_DepLib",
       "lib_Lib",

--- a/tool/test/expect/haxe_4_1/node-release-test4.json
+++ b/tool/test/expect/haxe_4_1/node-release-test4.json
@@ -71,6 +71,9 @@
   {
     "isMain": false,
     "isLib": true,
+    "libParams": [
+      "lib_"
+    ],
     "name": "lib",
     "nodes": [
       "lib_DepLib",

--- a/tool/test/expect/haxe_4_1/node-release-test5.json
+++ b/tool/test/expect/haxe_4_1/node-release-test5.json
@@ -36,6 +36,7 @@
     "isMain": false,
     "isLib": false,
     "name": "CaseA",
+    "alias": "CaseA",
     "nodes": [
       "CaseA"
     ],
@@ -53,6 +54,7 @@
     "isMain": false,
     "isLib": false,
     "name": "CaseB",
+    "alias": "CaseB",
     "nodes": [
       "CaseB",
       "DepB",
@@ -78,6 +80,7 @@
       "a_$b_C_$_$d"
     ],
     "name": "lib",
+    "alias": "lib",
     "nodes": [
       "a_$b_C_$_$d",
       "lib_DepLib",

--- a/tool/test/expect/haxe_4_1/node-release-test5.json
+++ b/tool/test/expect/haxe_4_1/node-release-test5.json
@@ -73,6 +73,10 @@
   {
     "isMain": false,
     "isLib": true,
+    "libParams": [
+      "lib_",
+      "a_$b_C_$_$d"
+    ],
     "name": "lib",
     "nodes": [
       "a_$b_C_$_$d",

--- a/tool/test/expect/haxe_4_1/node-release-test6.json
+++ b/tool/test/expect/haxe_4_1/node-release-test6.json
@@ -22,6 +22,7 @@
     "isMain": false,
     "isLib": false,
     "name": "CaseA",
+    "alias": "CaseA",
     "nodes": [
       "CaseA",
       "DepAB",

--- a/tool/test/expect/haxe_4_1/node-release-test7.json
+++ b/tool/test/expect/haxe_4_1/node-release-test7.json
@@ -20,6 +20,7 @@
     "isMain": false,
     "isLib": false,
     "name": "CaseD",
+    "alias": "CaseD",
     "nodes": [
       "CaseD",
       "CycleD"

--- a/tool/test/expect/haxe_4_1/node-release-test9.json
+++ b/tool/test/expect/haxe_4_1/node-release-test9.json
@@ -20,6 +20,7 @@
     "isMain": false,
     "isLib": false,
     "name": "CaseD",
+    "alias": "CaseD",
     "nodes": [
       "CaseD"
     ],

--- a/tool/test/expect/haxe_4_1/web-debug-closure-testinterop.json
+++ b/tool/test/expect/haxe_4_1/web-debug-closure-testinterop.json
@@ -39,6 +39,7 @@
     "isMain": false,
     "isLib": false,
     "name": "CaseInterop",
+    "alias": "CaseInterop",
     "nodes": [
       "CaseInterop"
     ],
@@ -60,6 +61,7 @@
     "isMain": false,
     "isLib": false,
     "name": "a_$b_C_$_$d",
+    "alias": "a_$b_C_$_$d",
     "nodes": [
       "a_$b_C_$_$d"
     ],

--- a/tool/test/expect/haxe_4_1/web-debug-test1.json
+++ b/tool/test/expect/haxe_4_1/web-debug-test1.json
@@ -35,6 +35,7 @@
     "isMain": false,
     "isLib": false,
     "name": "CaseA",
+    "alias": "CaseA",
     "nodes": [
       "CaseA"
     ],
@@ -51,6 +52,7 @@
     "isMain": false,
     "isLib": false,
     "name": "CaseB",
+    "alias": "CaseB",
     "nodes": [
       "CaseB",
       "DepB"

--- a/tool/test/expect/haxe_4_1/web-debug-test10.json
+++ b/tool/test/expect/haxe_4_1/web-debug-test10.json
@@ -30,6 +30,7 @@
     "isMain": false,
     "isLib": false,
     "name": "CaseE",
+    "alias": "CaseE",
     "nodes": [
       "CaseE"
     ],
@@ -49,6 +50,7 @@
     "isMain": false,
     "isLib": false,
     "name": "DepE",
+    "alias": "DepE",
     "nodes": [
       "DepE"
     ],

--- a/tool/test/expect/haxe_4_1/web-debug-test11.json
+++ b/tool/test/expect/haxe_4_1/web-debug-test11.json
@@ -27,6 +27,7 @@
     "isMain": false,
     "isLib": false,
     "name": "CaseF",
+    "alias": "CaseF",
     "nodes": [
       "$extend",
       "CaseF",

--- a/tool/test/expect/haxe_4_1/web-debug-test12.json
+++ b/tool/test/expect/haxe_4_1/web-debug-test12.json
@@ -26,6 +26,10 @@
   {
     "isMain": false,
     "isLib": true,
+    "libParams": [
+      "lib_",
+      "a_$b_C_$_$d"
+    ],
     "name": "lib",
     "nodes": [
       "a_$b_C_$_$d",

--- a/tool/test/expect/haxe_4_1/web-debug-test12.json
+++ b/tool/test/expect/haxe_4_1/web-debug-test12.json
@@ -31,6 +31,7 @@
       "a_$b_C_$_$d"
     ],
     "name": "lib",
+    "alias": "lib",
     "nodes": [
       "a_$b_C_$_$d",
       "lib_DepLib",

--- a/tool/test/expect/haxe_4_1/web-debug-test13.json
+++ b/tool/test/expect/haxe_4_1/web-debug-test13.json
@@ -27,6 +27,7 @@
     "isMain": false,
     "isLib": false,
     "name": "a_$b_Exposed",
+    "alias": "a_$b_Exposed",
     "nodes": [
       "a_$b_Exposed",
       "a_$b_SubExposed"

--- a/tool/test/expect/haxe_4_1/web-debug-test14.json
+++ b/tool/test/expect/haxe_4_1/web-debug-test14.json
@@ -23,6 +23,7 @@
     "isMain": false,
     "isLib": false,
     "name": "a_$b_Exposed",
+    "alias": "a_$b_Exposed",
     "nodes": [
       "a_$b_Exposed",
       "a_$b_SubExposed"

--- a/tool/test/expect/haxe_4_1/web-debug-test15.json
+++ b/tool/test/expect/haxe_4_1/web-debug-test15.json
@@ -27,6 +27,7 @@
     "isMain": false,
     "isLib": false,
     "name": "CaseG",
+    "alias": "CaseG",
     "nodes": [
       "CaseG"
     ],

--- a/tool/test/expect/haxe_4_1/web-debug-test2.json
+++ b/tool/test/expect/haxe_4_1/web-debug-test2.json
@@ -35,6 +35,7 @@
     "isMain": false,
     "isLib": false,
     "name": "CaseA",
+    "alias": "CaseA",
     "nodes": [
       "CaseA"
     ],
@@ -51,6 +52,7 @@
     "isMain": false,
     "isLib": false,
     "name": "CaseB",
+    "alias": "CaseB",
     "nodes": [
       "CaseB",
       "DepB"

--- a/tool/test/expect/haxe_4_1/web-debug-test3.json
+++ b/tool/test/expect/haxe_4_1/web-debug-test3.json
@@ -31,6 +31,7 @@
     "isMain": false,
     "isLib": false,
     "name": "CaseC",
+    "alias": "CaseC",
     "nodes": [
       "CaseC"
     ],
@@ -49,6 +50,7 @@
     "isMain": false,
     "isLib": false,
     "name": "DepC",
+    "alias": "DepC",
     "nodes": [
       "DepC",
       "DepSubC"
@@ -71,6 +73,7 @@
     "isMain": false,
     "isLib": false,
     "name": "SubC",
+    "alias": "SubC",
     "nodes": [
       "SubC"
     ],
@@ -87,6 +90,7 @@
     "isMain": false,
     "isLib": false,
     "name": "SubC2",
+    "alias": "SubC2",
     "nodes": [
       "SubC2"
     ],

--- a/tool/test/expect/haxe_4_1/web-debug-test4.json
+++ b/tool/test/expect/haxe_4_1/web-debug-test4.json
@@ -72,6 +72,9 @@
   {
     "isMain": false,
     "isLib": true,
+    "libParams": [
+      "lib_"
+    ],
     "name": "lib",
     "nodes": [
       "lib_DepLib",

--- a/tool/test/expect/haxe_4_1/web-debug-test4.json
+++ b/tool/test/expect/haxe_4_1/web-debug-test4.json
@@ -37,6 +37,7 @@
     "isMain": false,
     "isLib": false,
     "name": "CaseA",
+    "alias": "CaseA",
     "nodes": [
       "CaseA"
     ],
@@ -54,6 +55,7 @@
     "isMain": false,
     "isLib": false,
     "name": "CaseB",
+    "alias": "CaseB",
     "nodes": [
       "CaseB",
       "DepB"
@@ -76,6 +78,7 @@
       "lib_"
     ],
     "name": "lib",
+    "alias": "lib",
     "nodes": [
       "lib_DepLib",
       "lib_Lib",

--- a/tool/test/expect/haxe_4_1/web-debug-test5.json
+++ b/tool/test/expect/haxe_4_1/web-debug-test5.json
@@ -39,6 +39,7 @@
     "isMain": false,
     "isLib": false,
     "name": "CaseA",
+    "alias": "CaseA",
     "nodes": [
       "CaseA"
     ],
@@ -56,6 +57,7 @@
     "isMain": false,
     "isLib": false,
     "name": "CaseB",
+    "alias": "CaseB",
     "nodes": [
       "CaseB",
       "DepB"
@@ -79,6 +81,7 @@
       "a_$b_C_$_$d"
     ],
     "name": "lib",
+    "alias": "lib",
     "nodes": [
       "a_$b_C_$_$d",
       "lib_DepLib",

--- a/tool/test/expect/haxe_4_1/web-debug-test5.json
+++ b/tool/test/expect/haxe_4_1/web-debug-test5.json
@@ -74,6 +74,10 @@
   {
     "isMain": false,
     "isLib": true,
+    "libParams": [
+      "lib_",
+      "a_$b_C_$_$d"
+    ],
     "name": "lib",
     "nodes": [
       "a_$b_C_$_$d",

--- a/tool/test/expect/haxe_4_1/web-debug-test6.json
+++ b/tool/test/expect/haxe_4_1/web-debug-test6.json
@@ -29,6 +29,7 @@
     "isMain": false,
     "isLib": false,
     "name": "CaseA",
+    "alias": "CaseA",
     "nodes": [
       "CaseA",
       "DepAB",

--- a/tool/test/expect/haxe_4_1/web-debug-test7.json
+++ b/tool/test/expect/haxe_4_1/web-debug-test7.json
@@ -27,6 +27,7 @@
     "isMain": false,
     "isLib": false,
     "name": "CaseD",
+    "alias": "CaseD",
     "nodes": [
       "CaseD",
       "CycleD"

--- a/tool/test/expect/haxe_4_1/web-debug-test9.json
+++ b/tool/test/expect/haxe_4_1/web-debug-test9.json
@@ -27,6 +27,7 @@
     "isMain": false,
     "isLib": false,
     "name": "CaseD",
+    "alias": "CaseD",
     "nodes": [
       "CaseD"
     ],

--- a/tool/test/expect/haxe_4_1/web-debug-testinterop.json
+++ b/tool/test/expect/haxe_4_1/web-debug-testinterop.json
@@ -39,6 +39,7 @@
     "isMain": false,
     "isLib": false,
     "name": "CaseInterop",
+    "alias": "CaseInterop",
     "nodes": [
       "CaseInterop"
     ],
@@ -60,6 +61,7 @@
     "isMain": false,
     "isLib": false,
     "name": "a_$b_C_$_$d",
+    "alias": "a_$b_C_$_$d",
     "nodes": [
       "a_$b_C_$_$d"
     ],

--- a/tool/test/expect/haxe_4_1/web-debug-uglify-testinterop.json
+++ b/tool/test/expect/haxe_4_1/web-debug-uglify-testinterop.json
@@ -39,6 +39,7 @@
     "isMain": false,
     "isLib": false,
     "name": "CaseInterop",
+    "alias": "CaseInterop",
     "nodes": [
       "CaseInterop"
     ],
@@ -60,6 +61,7 @@
     "isMain": false,
     "isLib": false,
     "name": "a_$b_C_$_$d",
+    "alias": "a_$b_C_$_$d",
     "nodes": [
       "a_$b_C_$_$d"
     ],

--- a/tool/test/expect/haxe_4_1/web-release-closure-testinterop.json
+++ b/tool/test/expect/haxe_4_1/web-release-closure-testinterop.json
@@ -38,6 +38,7 @@
     "isMain": false,
     "isLib": false,
     "name": "CaseInterop",
+    "alias": "CaseInterop",
     "nodes": [
       "CaseInterop"
     ],
@@ -59,6 +60,7 @@
     "isMain": false,
     "isLib": false,
     "name": "a_$b_C_$_$d",
+    "alias": "a_$b_C_$_$d",
     "nodes": [
       "a_$b_C_$_$d"
     ],

--- a/tool/test/expect/haxe_4_1/web-release-test1.json
+++ b/tool/test/expect/haxe_4_1/web-release-test1.json
@@ -33,6 +33,7 @@
     "isMain": false,
     "isLib": false,
     "name": "CaseA",
+    "alias": "CaseA",
     "nodes": [
       "CaseA"
     ],
@@ -49,6 +50,7 @@
     "isMain": false,
     "isLib": false,
     "name": "CaseB",
+    "alias": "CaseB",
     "nodes": [
       "CaseB",
       "DepB",

--- a/tool/test/expect/haxe_4_1/web-release-test10.json
+++ b/tool/test/expect/haxe_4_1/web-release-test10.json
@@ -27,6 +27,7 @@
     "isMain": false,
     "isLib": false,
     "name": "CaseE",
+    "alias": "CaseE",
     "nodes": [
       "CaseE"
     ],
@@ -46,6 +47,7 @@
     "isMain": false,
     "isLib": false,
     "name": "DepE",
+    "alias": "DepE",
     "nodes": [
       "DepE"
     ],

--- a/tool/test/expect/haxe_4_1/web-release-test11.json
+++ b/tool/test/expect/haxe_4_1/web-release-test11.json
@@ -24,6 +24,7 @@
     "isMain": false,
     "isLib": false,
     "name": "CaseF",
+    "alias": "CaseF",
     "nodes": [
       "$extend",
       "CaseF",

--- a/tool/test/expect/haxe_4_1/web-release-test12.json
+++ b/tool/test/expect/haxe_4_1/web-release-test12.json
@@ -26,6 +26,10 @@
   {
     "isMain": false,
     "isLib": true,
+    "libParams": [
+      "lib_",
+      "a_$b_C_$_$d"
+    ],
     "name": "lib",
     "nodes": [
       "a_$b_C_$_$d",

--- a/tool/test/expect/haxe_4_1/web-release-test12.json
+++ b/tool/test/expect/haxe_4_1/web-release-test12.json
@@ -31,6 +31,7 @@
       "a_$b_C_$_$d"
     ],
     "name": "lib",
+    "alias": "lib",
     "nodes": [
       "a_$b_C_$_$d",
       "lib_DepLib",

--- a/tool/test/expect/haxe_4_1/web-release-test13.json
+++ b/tool/test/expect/haxe_4_1/web-release-test13.json
@@ -24,6 +24,7 @@
     "isMain": false,
     "isLib": false,
     "name": "a_$b_Exposed",
+    "alias": "a_$b_Exposed",
     "nodes": [
       "a_$b_Exposed",
       "a_$b_SubExposed"

--- a/tool/test/expect/haxe_4_1/web-release-test14.json
+++ b/tool/test/expect/haxe_4_1/web-release-test14.json
@@ -20,6 +20,7 @@
     "isMain": false,
     "isLib": false,
     "name": "a_$b_Exposed",
+    "alias": "a_$b_Exposed",
     "nodes": [
       "a_$b_Exposed",
       "a_$b_SubExposed"

--- a/tool/test/expect/haxe_4_1/web-release-test15.json
+++ b/tool/test/expect/haxe_4_1/web-release-test15.json
@@ -24,6 +24,7 @@
     "isMain": false,
     "isLib": false,
     "name": "CaseG",
+    "alias": "CaseG",
     "nodes": [
       "CaseG"
     ],

--- a/tool/test/expect/haxe_4_1/web-release-test2.json
+++ b/tool/test/expect/haxe_4_1/web-release-test2.json
@@ -33,6 +33,7 @@
     "isMain": false,
     "isLib": false,
     "name": "CaseA",
+    "alias": "CaseA",
     "nodes": [
       "CaseA"
     ],
@@ -49,6 +50,7 @@
     "isMain": false,
     "isLib": false,
     "name": "CaseB",
+    "alias": "CaseB",
     "nodes": [
       "CaseB",
       "DepB",

--- a/tool/test/expect/haxe_4_1/web-release-test3.json
+++ b/tool/test/expect/haxe_4_1/web-release-test3.json
@@ -28,6 +28,7 @@
     "isMain": false,
     "isLib": false,
     "name": "CaseC",
+    "alias": "CaseC",
     "nodes": [
       "CaseC"
     ],
@@ -46,6 +47,7 @@
     "isMain": false,
     "isLib": false,
     "name": "DepC",
+    "alias": "DepC",
     "nodes": [
       "DepC",
       "DepSubC"
@@ -68,6 +70,7 @@
     "isMain": false,
     "isLib": false,
     "name": "SubC",
+    "alias": "SubC",
     "nodes": [
       "SubC"
     ],
@@ -84,6 +87,7 @@
     "isMain": false,
     "isLib": false,
     "name": "SubC2",
+    "alias": "SubC2",
     "nodes": [
       "SubC2"
     ],

--- a/tool/test/expect/haxe_4_1/web-release-test4.json
+++ b/tool/test/expect/haxe_4_1/web-release-test4.json
@@ -72,6 +72,9 @@
   {
     "isMain": false,
     "isLib": true,
+    "libParams": [
+      "lib_"
+    ],
     "name": "lib",
     "nodes": [
       "lib_DepLib",

--- a/tool/test/expect/haxe_4_1/web-release-test4.json
+++ b/tool/test/expect/haxe_4_1/web-release-test4.json
@@ -35,6 +35,7 @@
     "isMain": false,
     "isLib": false,
     "name": "CaseA",
+    "alias": "CaseA",
     "nodes": [
       "CaseA"
     ],
@@ -52,6 +53,7 @@
     "isMain": false,
     "isLib": false,
     "name": "CaseB",
+    "alias": "CaseB",
     "nodes": [
       "CaseB",
       "DepB",
@@ -76,6 +78,7 @@
       "lib_"
     ],
     "name": "lib",
+    "alias": "lib",
     "nodes": [
       "lib_DepLib",
       "lib_Lib",

--- a/tool/test/expect/haxe_4_1/web-release-test5.json
+++ b/tool/test/expect/haxe_4_1/web-release-test5.json
@@ -37,6 +37,7 @@
     "isMain": false,
     "isLib": false,
     "name": "CaseA",
+    "alias": "CaseA",
     "nodes": [
       "CaseA"
     ],
@@ -54,6 +55,7 @@
     "isMain": false,
     "isLib": false,
     "name": "CaseB",
+    "alias": "CaseB",
     "nodes": [
       "CaseB",
       "DepB",
@@ -79,6 +81,7 @@
       "a_$b_C_$_$d"
     ],
     "name": "lib",
+    "alias": "lib",
     "nodes": [
       "a_$b_C_$_$d",
       "lib_DepLib",

--- a/tool/test/expect/haxe_4_1/web-release-test5.json
+++ b/tool/test/expect/haxe_4_1/web-release-test5.json
@@ -74,6 +74,10 @@
   {
     "isMain": false,
     "isLib": true,
+    "libParams": [
+      "lib_",
+      "a_$b_C_$_$d"
+    ],
     "name": "lib",
     "nodes": [
       "a_$b_C_$_$d",

--- a/tool/test/expect/haxe_4_1/web-release-test6.json
+++ b/tool/test/expect/haxe_4_1/web-release-test6.json
@@ -26,6 +26,7 @@
     "isMain": false,
     "isLib": false,
     "name": "CaseA",
+    "alias": "CaseA",
     "nodes": [
       "CaseA",
       "DepAB",

--- a/tool/test/expect/haxe_4_1/web-release-test7.json
+++ b/tool/test/expect/haxe_4_1/web-release-test7.json
@@ -24,6 +24,7 @@
     "isMain": false,
     "isLib": false,
     "name": "CaseD",
+    "alias": "CaseD",
     "nodes": [
       "CaseD",
       "CycleD"

--- a/tool/test/expect/haxe_4_1/web-release-test9.json
+++ b/tool/test/expect/haxe_4_1/web-release-test9.json
@@ -24,6 +24,7 @@
     "isMain": false,
     "isLib": false,
     "name": "CaseD",
+    "alias": "CaseD",
     "nodes": [
       "CaseD"
     ],

--- a/tool/test/expect/haxe_4_1/web-release-testinterop.json
+++ b/tool/test/expect/haxe_4_1/web-release-testinterop.json
@@ -38,6 +38,7 @@
     "isMain": false,
     "isLib": false,
     "name": "CaseInterop",
+    "alias": "CaseInterop",
     "nodes": [
       "CaseInterop"
     ],
@@ -59,6 +60,7 @@
     "isMain": false,
     "isLib": false,
     "name": "a_$b_C_$_$d",
+    "alias": "a_$b_C_$_$d",
     "nodes": [
       "a_$b_C_$_$d"
     ],

--- a/tool/test/expect/haxe_4_1/web-release-uglify-testinterop.json
+++ b/tool/test/expect/haxe_4_1/web-release-uglify-testinterop.json
@@ -38,6 +38,7 @@
     "isMain": false,
     "isLib": false,
     "name": "CaseInterop",
+    "alias": "CaseInterop",
     "nodes": [
       "CaseInterop"
     ],
@@ -59,6 +60,7 @@
     "isMain": false,
     "isLib": false,
     "name": "a_$b_C_$_$d",
+    "alias": "a_$b_C_$_$d",
     "nodes": [
       "a_$b_C_$_$d"
     ],

--- a/tool/test/expect/haxe_4_1_es6/node-debug-test1.json
+++ b/tool/test/expect/haxe_4_1_es6/node-debug-test1.json
@@ -29,6 +29,7 @@
     "isMain": false,
     "isLib": false,
     "name": "CaseA",
+    "alias": "CaseA",
     "nodes": [
       "CaseA"
     ],
@@ -45,6 +46,7 @@
     "isMain": false,
     "isLib": false,
     "name": "CaseB",
+    "alias": "CaseB",
     "nodes": [
       "CaseB",
       "DepB"

--- a/tool/test/expect/haxe_4_1_es6/node-debug-test10.json
+++ b/tool/test/expect/haxe_4_1_es6/node-debug-test10.json
@@ -22,6 +22,7 @@
     "isMain": false,
     "isLib": false,
     "name": "CaseE",
+    "alias": "CaseE",
     "nodes": [
       "CaseE"
     ],
@@ -40,6 +41,7 @@
     "isMain": false,
     "isLib": false,
     "name": "DepE",
+    "alias": "DepE",
     "nodes": [
       "DepE"
     ],

--- a/tool/test/expect/haxe_4_1_es6/node-debug-test11.json
+++ b/tool/test/expect/haxe_4_1_es6/node-debug-test11.json
@@ -20,6 +20,7 @@
     "isMain": false,
     "isLib": false,
     "name": "CaseF",
+    "alias": "CaseF",
     "nodes": [
       "CaseF",
       "haxe_Exception",

--- a/tool/test/expect/haxe_4_1_es6/node-debug-test12.json
+++ b/tool/test/expect/haxe_4_1_es6/node-debug-test12.json
@@ -30,6 +30,7 @@
       "a_$b_C_$_$d"
     ],
     "name": "lib",
+    "alias": "lib",
     "nodes": [
       "a_$b_C_$_$d",
       "lib_DepLib",

--- a/tool/test/expect/haxe_4_1_es6/node-debug-test12.json
+++ b/tool/test/expect/haxe_4_1_es6/node-debug-test12.json
@@ -25,6 +25,10 @@
   {
     "isMain": false,
     "isLib": true,
+    "libParams": [
+      "lib_",
+      "a_$b_C_$_$d"
+    ],
     "name": "lib",
     "nodes": [
       "a_$b_C_$_$d",

--- a/tool/test/expect/haxe_4_1_es6/node-debug-test13.json
+++ b/tool/test/expect/haxe_4_1_es6/node-debug-test13.json
@@ -20,6 +20,7 @@
     "isMain": false,
     "isLib": false,
     "name": "a_$b_Exposed",
+    "alias": "a_$b_Exposed",
     "nodes": [
       "a_$b_Exposed",
       "a_$b_SubExposed"

--- a/tool/test/expect/haxe_4_1_es6/node-debug-test14.json
+++ b/tool/test/expect/haxe_4_1_es6/node-debug-test14.json
@@ -17,6 +17,7 @@
     "isMain": false,
     "isLib": false,
     "name": "a_$b_Exposed",
+    "alias": "a_$b_Exposed",
     "nodes": [
       "a_$b_Exposed",
       "a_$b_SubExposed"

--- a/tool/test/expect/haxe_4_1_es6/node-debug-test15.json
+++ b/tool/test/expect/haxe_4_1_es6/node-debug-test15.json
@@ -21,6 +21,7 @@
     "isMain": false,
     "isLib": false,
     "name": "CaseG",
+    "alias": "CaseG",
     "nodes": [
       "CaseG"
     ],

--- a/tool/test/expect/haxe_4_1_es6/node-debug-test2.json
+++ b/tool/test/expect/haxe_4_1_es6/node-debug-test2.json
@@ -29,6 +29,7 @@
     "isMain": false,
     "isLib": false,
     "name": "CaseA",
+    "alias": "CaseA",
     "nodes": [
       "CaseA"
     ],
@@ -45,6 +46,7 @@
     "isMain": false,
     "isLib": false,
     "name": "CaseB",
+    "alias": "CaseB",
     "nodes": [
       "CaseB",
       "DepB"

--- a/tool/test/expect/haxe_4_1_es6/node-debug-test3.json
+++ b/tool/test/expect/haxe_4_1_es6/node-debug-test3.json
@@ -23,6 +23,7 @@
     "isMain": false,
     "isLib": false,
     "name": "CaseC",
+    "alias": "CaseC",
     "nodes": [
       "CaseC"
     ],
@@ -40,6 +41,7 @@
     "isMain": false,
     "isLib": false,
     "name": "DepC",
+    "alias": "DepC",
     "nodes": [
       "DepC",
       "DepSubC"
@@ -61,6 +63,7 @@
     "isMain": false,
     "isLib": false,
     "name": "SubC",
+    "alias": "SubC",
     "nodes": [
       "SubC"
     ],
@@ -77,6 +80,7 @@
     "isMain": false,
     "isLib": false,
     "name": "SubC2",
+    "alias": "SubC2",
     "nodes": [
       "SubC2"
     ],

--- a/tool/test/expect/haxe_4_1_es6/node-debug-test4.json
+++ b/tool/test/expect/haxe_4_1_es6/node-debug-test4.json
@@ -69,6 +69,9 @@
   {
     "isMain": false,
     "isLib": true,
+    "libParams": [
+      "lib_"
+    ],
     "name": "lib",
     "nodes": [
       "lib_DepLib",

--- a/tool/test/expect/haxe_4_1_es6/node-debug-test4.json
+++ b/tool/test/expect/haxe_4_1_es6/node-debug-test4.json
@@ -34,6 +34,7 @@
     "isMain": false,
     "isLib": false,
     "name": "CaseA",
+    "alias": "CaseA",
     "nodes": [
       "CaseA"
     ],
@@ -51,6 +52,7 @@
     "isMain": false,
     "isLib": false,
     "name": "CaseB",
+    "alias": "CaseB",
     "nodes": [
       "CaseB",
       "DepB"
@@ -73,6 +75,7 @@
       "lib_"
     ],
     "name": "lib",
+    "alias": "lib",
     "nodes": [
       "lib_DepLib",
       "lib_Lib",

--- a/tool/test/expect/haxe_4_1_es6/node-debug-test5.json
+++ b/tool/test/expect/haxe_4_1_es6/node-debug-test5.json
@@ -36,6 +36,7 @@
     "isMain": false,
     "isLib": false,
     "name": "CaseA",
+    "alias": "CaseA",
     "nodes": [
       "CaseA"
     ],
@@ -53,6 +54,7 @@
     "isMain": false,
     "isLib": false,
     "name": "CaseB",
+    "alias": "CaseB",
     "nodes": [
       "CaseB",
       "DepB"
@@ -76,6 +78,7 @@
       "a_$b_C_$_$d"
     ],
     "name": "lib",
+    "alias": "lib",
     "nodes": [
       "a_$b_C_$_$d",
       "lib_DepLib",

--- a/tool/test/expect/haxe_4_1_es6/node-debug-test5.json
+++ b/tool/test/expect/haxe_4_1_es6/node-debug-test5.json
@@ -71,6 +71,10 @@
   {
     "isMain": false,
     "isLib": true,
+    "libParams": [
+      "lib_",
+      "a_$b_C_$_$d"
+    ],
     "name": "lib",
     "nodes": [
       "a_$b_C_$_$d",

--- a/tool/test/expect/haxe_4_1_es6/node-debug-test6.json
+++ b/tool/test/expect/haxe_4_1_es6/node-debug-test6.json
@@ -22,6 +22,7 @@
     "isMain": false,
     "isLib": false,
     "name": "CaseA",
+    "alias": "CaseA",
     "nodes": [
       "CaseA",
       "DepAB",

--- a/tool/test/expect/haxe_4_1_es6/node-debug-test7.json
+++ b/tool/test/expect/haxe_4_1_es6/node-debug-test7.json
@@ -20,6 +20,7 @@
     "isMain": false,
     "isLib": false,
     "name": "CaseD",
+    "alias": "CaseD",
     "nodes": [
       "CaseD",
       "CycleD"

--- a/tool/test/expect/haxe_4_1_es6/node-debug-test9.json
+++ b/tool/test/expect/haxe_4_1_es6/node-debug-test9.json
@@ -20,6 +20,7 @@
     "isMain": false,
     "isLib": false,
     "name": "CaseD",
+    "alias": "CaseD",
     "nodes": [
       "CaseD"
     ],

--- a/tool/test/expect/haxe_4_1_es6/node-release-test1.json
+++ b/tool/test/expect/haxe_4_1_es6/node-release-test1.json
@@ -29,6 +29,7 @@
     "isMain": false,
     "isLib": false,
     "name": "CaseA",
+    "alias": "CaseA",
     "nodes": [
       "CaseA"
     ],
@@ -45,6 +46,7 @@
     "isMain": false,
     "isLib": false,
     "name": "CaseB",
+    "alias": "CaseB",
     "nodes": [
       "CaseB",
       "DepB",

--- a/tool/test/expect/haxe_4_1_es6/node-release-test10.json
+++ b/tool/test/expect/haxe_4_1_es6/node-release-test10.json
@@ -22,6 +22,7 @@
     "isMain": false,
     "isLib": false,
     "name": "CaseE",
+    "alias": "CaseE",
     "nodes": [
       "CaseE"
     ],
@@ -40,6 +41,7 @@
     "isMain": false,
     "isLib": false,
     "name": "DepE",
+    "alias": "DepE",
     "nodes": [
       "DepE"
     ],

--- a/tool/test/expect/haxe_4_1_es6/node-release-test11.json
+++ b/tool/test/expect/haxe_4_1_es6/node-release-test11.json
@@ -20,6 +20,7 @@
     "isMain": false,
     "isLib": false,
     "name": "CaseF",
+    "alias": "CaseF",
     "nodes": [
       "CaseF",
       "haxe_Exception",

--- a/tool/test/expect/haxe_4_1_es6/node-release-test12.json
+++ b/tool/test/expect/haxe_4_1_es6/node-release-test12.json
@@ -30,6 +30,7 @@
       "a_$b_C_$_$d"
     ],
     "name": "lib",
+    "alias": "lib",
     "nodes": [
       "a_$b_C_$_$d",
       "lib_DepLib",

--- a/tool/test/expect/haxe_4_1_es6/node-release-test12.json
+++ b/tool/test/expect/haxe_4_1_es6/node-release-test12.json
@@ -25,6 +25,10 @@
   {
     "isMain": false,
     "isLib": true,
+    "libParams": [
+      "lib_",
+      "a_$b_C_$_$d"
+    ],
     "name": "lib",
     "nodes": [
       "a_$b_C_$_$d",

--- a/tool/test/expect/haxe_4_1_es6/node-release-test13.json
+++ b/tool/test/expect/haxe_4_1_es6/node-release-test13.json
@@ -20,6 +20,7 @@
     "isMain": false,
     "isLib": false,
     "name": "a_$b_Exposed",
+    "alias": "a_$b_Exposed",
     "nodes": [
       "a_$b_Exposed",
       "a_$b_SubExposed"

--- a/tool/test/expect/haxe_4_1_es6/node-release-test14.json
+++ b/tool/test/expect/haxe_4_1_es6/node-release-test14.json
@@ -17,6 +17,7 @@
     "isMain": false,
     "isLib": false,
     "name": "a_$b_Exposed",
+    "alias": "a_$b_Exposed",
     "nodes": [
       "a_$b_Exposed",
       "a_$b_SubExposed"

--- a/tool/test/expect/haxe_4_1_es6/node-release-test15.json
+++ b/tool/test/expect/haxe_4_1_es6/node-release-test15.json
@@ -21,6 +21,7 @@
     "isMain": false,
     "isLib": false,
     "name": "CaseG",
+    "alias": "CaseG",
     "nodes": [
       "CaseG"
     ],

--- a/tool/test/expect/haxe_4_1_es6/node-release-test2.json
+++ b/tool/test/expect/haxe_4_1_es6/node-release-test2.json
@@ -29,6 +29,7 @@
     "isMain": false,
     "isLib": false,
     "name": "CaseA",
+    "alias": "CaseA",
     "nodes": [
       "CaseA"
     ],
@@ -45,6 +46,7 @@
     "isMain": false,
     "isLib": false,
     "name": "CaseB",
+    "alias": "CaseB",
     "nodes": [
       "CaseB",
       "DepB",

--- a/tool/test/expect/haxe_4_1_es6/node-release-test3.json
+++ b/tool/test/expect/haxe_4_1_es6/node-release-test3.json
@@ -23,6 +23,7 @@
     "isMain": false,
     "isLib": false,
     "name": "CaseC",
+    "alias": "CaseC",
     "nodes": [
       "CaseC"
     ],
@@ -40,6 +41,7 @@
     "isMain": false,
     "isLib": false,
     "name": "DepC",
+    "alias": "DepC",
     "nodes": [
       "DepC",
       "DepSubC"
@@ -61,6 +63,7 @@
     "isMain": false,
     "isLib": false,
     "name": "SubC",
+    "alias": "SubC",
     "nodes": [
       "SubC"
     ],
@@ -77,6 +80,7 @@
     "isMain": false,
     "isLib": false,
     "name": "SubC2",
+    "alias": "SubC2",
     "nodes": [
       "SubC2"
     ],

--- a/tool/test/expect/haxe_4_1_es6/node-release-test4.json
+++ b/tool/test/expect/haxe_4_1_es6/node-release-test4.json
@@ -34,6 +34,7 @@
     "isMain": false,
     "isLib": false,
     "name": "CaseA",
+    "alias": "CaseA",
     "nodes": [
       "CaseA"
     ],
@@ -51,6 +52,7 @@
     "isMain": false,
     "isLib": false,
     "name": "CaseB",
+    "alias": "CaseB",
     "nodes": [
       "CaseB",
       "DepB",
@@ -75,6 +77,7 @@
       "lib_"
     ],
     "name": "lib",
+    "alias": "lib",
     "nodes": [
       "lib_DepLib",
       "lib_Lib",

--- a/tool/test/expect/haxe_4_1_es6/node-release-test4.json
+++ b/tool/test/expect/haxe_4_1_es6/node-release-test4.json
@@ -71,6 +71,9 @@
   {
     "isMain": false,
     "isLib": true,
+    "libParams": [
+      "lib_"
+    ],
     "name": "lib",
     "nodes": [
       "lib_DepLib",

--- a/tool/test/expect/haxe_4_1_es6/node-release-test5.json
+++ b/tool/test/expect/haxe_4_1_es6/node-release-test5.json
@@ -36,6 +36,7 @@
     "isMain": false,
     "isLib": false,
     "name": "CaseA",
+    "alias": "CaseA",
     "nodes": [
       "CaseA"
     ],
@@ -53,6 +54,7 @@
     "isMain": false,
     "isLib": false,
     "name": "CaseB",
+    "alias": "CaseB",
     "nodes": [
       "CaseB",
       "DepB",
@@ -78,6 +80,7 @@
       "a_$b_C_$_$d"
     ],
     "name": "lib",
+    "alias": "lib",
     "nodes": [
       "a_$b_C_$_$d",
       "lib_DepLib",

--- a/tool/test/expect/haxe_4_1_es6/node-release-test5.json
+++ b/tool/test/expect/haxe_4_1_es6/node-release-test5.json
@@ -73,6 +73,10 @@
   {
     "isMain": false,
     "isLib": true,
+    "libParams": [
+      "lib_",
+      "a_$b_C_$_$d"
+    ],
     "name": "lib",
     "nodes": [
       "a_$b_C_$_$d",

--- a/tool/test/expect/haxe_4_1_es6/node-release-test6.json
+++ b/tool/test/expect/haxe_4_1_es6/node-release-test6.json
@@ -22,6 +22,7 @@
     "isMain": false,
     "isLib": false,
     "name": "CaseA",
+    "alias": "CaseA",
     "nodes": [
       "CaseA",
       "DepAB",

--- a/tool/test/expect/haxe_4_1_es6/node-release-test7.json
+++ b/tool/test/expect/haxe_4_1_es6/node-release-test7.json
@@ -20,6 +20,7 @@
     "isMain": false,
     "isLib": false,
     "name": "CaseD",
+    "alias": "CaseD",
     "nodes": [
       "CaseD",
       "CycleD"

--- a/tool/test/expect/haxe_4_1_es6/node-release-test9.json
+++ b/tool/test/expect/haxe_4_1_es6/node-release-test9.json
@@ -20,6 +20,7 @@
     "isMain": false,
     "isLib": false,
     "name": "CaseD",
+    "alias": "CaseD",
     "nodes": [
       "CaseD"
     ],

--- a/tool/test/expect/haxe_4_1_es6/web-debug-closure-testinterop.json
+++ b/tool/test/expect/haxe_4_1_es6/web-debug-closure-testinterop.json
@@ -38,6 +38,7 @@
     "isMain": false,
     "isLib": false,
     "name": "CaseInterop",
+    "alias": "CaseInterop",
     "nodes": [
       "CaseInterop"
     ],
@@ -59,6 +60,7 @@
     "isMain": false,
     "isLib": false,
     "name": "a_$b_C_$_$d",
+    "alias": "a_$b_C_$_$d",
     "nodes": [
       "a_$b_C_$_$d"
     ],

--- a/tool/test/expect/haxe_4_1_es6/web-debug-test1.json
+++ b/tool/test/expect/haxe_4_1_es6/web-debug-test1.json
@@ -35,6 +35,7 @@
     "isMain": false,
     "isLib": false,
     "name": "CaseA",
+    "alias": "CaseA",
     "nodes": [
       "CaseA"
     ],
@@ -51,6 +52,7 @@
     "isMain": false,
     "isLib": false,
     "name": "CaseB",
+    "alias": "CaseB",
     "nodes": [
       "CaseB",
       "DepB"

--- a/tool/test/expect/haxe_4_1_es6/web-debug-test10.json
+++ b/tool/test/expect/haxe_4_1_es6/web-debug-test10.json
@@ -30,6 +30,7 @@
     "isMain": false,
     "isLib": false,
     "name": "CaseE",
+    "alias": "CaseE",
     "nodes": [
       "CaseE"
     ],
@@ -49,6 +50,7 @@
     "isMain": false,
     "isLib": false,
     "name": "DepE",
+    "alias": "DepE",
     "nodes": [
       "DepE"
     ],

--- a/tool/test/expect/haxe_4_1_es6/web-debug-test11.json
+++ b/tool/test/expect/haxe_4_1_es6/web-debug-test11.json
@@ -27,6 +27,7 @@
     "isMain": false,
     "isLib": false,
     "name": "CaseF",
+    "alias": "CaseF",
     "nodes": [
       "CaseF",
       "haxe_Exception",

--- a/tool/test/expect/haxe_4_1_es6/web-debug-test12.json
+++ b/tool/test/expect/haxe_4_1_es6/web-debug-test12.json
@@ -26,6 +26,10 @@
   {
     "isMain": false,
     "isLib": true,
+    "libParams": [
+      "lib_",
+      "a_$b_C_$_$d"
+    ],
     "name": "lib",
     "nodes": [
       "a_$b_C_$_$d",

--- a/tool/test/expect/haxe_4_1_es6/web-debug-test12.json
+++ b/tool/test/expect/haxe_4_1_es6/web-debug-test12.json
@@ -31,6 +31,7 @@
       "a_$b_C_$_$d"
     ],
     "name": "lib",
+    "alias": "lib",
     "nodes": [
       "a_$b_C_$_$d",
       "lib_DepLib",

--- a/tool/test/expect/haxe_4_1_es6/web-debug-test13.json
+++ b/tool/test/expect/haxe_4_1_es6/web-debug-test13.json
@@ -27,6 +27,7 @@
     "isMain": false,
     "isLib": false,
     "name": "a_$b_Exposed",
+    "alias": "a_$b_Exposed",
     "nodes": [
       "a_$b_Exposed",
       "a_$b_SubExposed"

--- a/tool/test/expect/haxe_4_1_es6/web-debug-test14.json
+++ b/tool/test/expect/haxe_4_1_es6/web-debug-test14.json
@@ -23,6 +23,7 @@
     "isMain": false,
     "isLib": false,
     "name": "a_$b_Exposed",
+    "alias": "a_$b_Exposed",
     "nodes": [
       "a_$b_Exposed",
       "a_$b_SubExposed"

--- a/tool/test/expect/haxe_4_1_es6/web-debug-test15.json
+++ b/tool/test/expect/haxe_4_1_es6/web-debug-test15.json
@@ -27,6 +27,7 @@
     "isMain": false,
     "isLib": false,
     "name": "CaseG",
+    "alias": "CaseG",
     "nodes": [
       "CaseG"
     ],

--- a/tool/test/expect/haxe_4_1_es6/web-debug-test2.json
+++ b/tool/test/expect/haxe_4_1_es6/web-debug-test2.json
@@ -35,6 +35,7 @@
     "isMain": false,
     "isLib": false,
     "name": "CaseA",
+    "alias": "CaseA",
     "nodes": [
       "CaseA"
     ],
@@ -51,6 +52,7 @@
     "isMain": false,
     "isLib": false,
     "name": "CaseB",
+    "alias": "CaseB",
     "nodes": [
       "CaseB",
       "DepB"

--- a/tool/test/expect/haxe_4_1_es6/web-debug-test3.json
+++ b/tool/test/expect/haxe_4_1_es6/web-debug-test3.json
@@ -31,6 +31,7 @@
     "isMain": false,
     "isLib": false,
     "name": "CaseC",
+    "alias": "CaseC",
     "nodes": [
       "CaseC"
     ],
@@ -49,6 +50,7 @@
     "isMain": false,
     "isLib": false,
     "name": "DepC",
+    "alias": "DepC",
     "nodes": [
       "DepC",
       "DepSubC"
@@ -71,6 +73,7 @@
     "isMain": false,
     "isLib": false,
     "name": "SubC",
+    "alias": "SubC",
     "nodes": [
       "SubC"
     ],
@@ -87,6 +90,7 @@
     "isMain": false,
     "isLib": false,
     "name": "SubC2",
+    "alias": "SubC2",
     "nodes": [
       "SubC2"
     ],

--- a/tool/test/expect/haxe_4_1_es6/web-debug-test4.json
+++ b/tool/test/expect/haxe_4_1_es6/web-debug-test4.json
@@ -72,6 +72,9 @@
   {
     "isMain": false,
     "isLib": true,
+    "libParams": [
+      "lib_"
+    ],
     "name": "lib",
     "nodes": [
       "lib_DepLib",

--- a/tool/test/expect/haxe_4_1_es6/web-debug-test4.json
+++ b/tool/test/expect/haxe_4_1_es6/web-debug-test4.json
@@ -37,6 +37,7 @@
     "isMain": false,
     "isLib": false,
     "name": "CaseA",
+    "alias": "CaseA",
     "nodes": [
       "CaseA"
     ],
@@ -54,6 +55,7 @@
     "isMain": false,
     "isLib": false,
     "name": "CaseB",
+    "alias": "CaseB",
     "nodes": [
       "CaseB",
       "DepB"
@@ -76,6 +78,7 @@
       "lib_"
     ],
     "name": "lib",
+    "alias": "lib",
     "nodes": [
       "lib_DepLib",
       "lib_Lib",

--- a/tool/test/expect/haxe_4_1_es6/web-debug-test5.json
+++ b/tool/test/expect/haxe_4_1_es6/web-debug-test5.json
@@ -39,6 +39,7 @@
     "isMain": false,
     "isLib": false,
     "name": "CaseA",
+    "alias": "CaseA",
     "nodes": [
       "CaseA"
     ],
@@ -56,6 +57,7 @@
     "isMain": false,
     "isLib": false,
     "name": "CaseB",
+    "alias": "CaseB",
     "nodes": [
       "CaseB",
       "DepB"
@@ -79,6 +81,7 @@
       "a_$b_C_$_$d"
     ],
     "name": "lib",
+    "alias": "lib",
     "nodes": [
       "a_$b_C_$_$d",
       "lib_DepLib",

--- a/tool/test/expect/haxe_4_1_es6/web-debug-test5.json
+++ b/tool/test/expect/haxe_4_1_es6/web-debug-test5.json
@@ -74,6 +74,10 @@
   {
     "isMain": false,
     "isLib": true,
+    "libParams": [
+      "lib_",
+      "a_$b_C_$_$d"
+    ],
     "name": "lib",
     "nodes": [
       "a_$b_C_$_$d",

--- a/tool/test/expect/haxe_4_1_es6/web-debug-test6.json
+++ b/tool/test/expect/haxe_4_1_es6/web-debug-test6.json
@@ -29,6 +29,7 @@
     "isMain": false,
     "isLib": false,
     "name": "CaseA",
+    "alias": "CaseA",
     "nodes": [
       "CaseA",
       "DepAB",

--- a/tool/test/expect/haxe_4_1_es6/web-debug-test7.json
+++ b/tool/test/expect/haxe_4_1_es6/web-debug-test7.json
@@ -27,6 +27,7 @@
     "isMain": false,
     "isLib": false,
     "name": "CaseD",
+    "alias": "CaseD",
     "nodes": [
       "CaseD",
       "CycleD"

--- a/tool/test/expect/haxe_4_1_es6/web-debug-test9.json
+++ b/tool/test/expect/haxe_4_1_es6/web-debug-test9.json
@@ -27,6 +27,7 @@
     "isMain": false,
     "isLib": false,
     "name": "CaseD",
+    "alias": "CaseD",
     "nodes": [
       "CaseD"
     ],

--- a/tool/test/expect/haxe_4_1_es6/web-debug-testinterop.json
+++ b/tool/test/expect/haxe_4_1_es6/web-debug-testinterop.json
@@ -38,6 +38,7 @@
     "isMain": false,
     "isLib": false,
     "name": "CaseInterop",
+    "alias": "CaseInterop",
     "nodes": [
       "CaseInterop"
     ],
@@ -59,6 +60,7 @@
     "isMain": false,
     "isLib": false,
     "name": "a_$b_C_$_$d",
+    "alias": "a_$b_C_$_$d",
     "nodes": [
       "a_$b_C_$_$d"
     ],

--- a/tool/test/expect/haxe_4_1_es6/web-debug-uglify-testinterop.json
+++ b/tool/test/expect/haxe_4_1_es6/web-debug-uglify-testinterop.json
@@ -38,6 +38,7 @@
     "isMain": false,
     "isLib": false,
     "name": "CaseInterop",
+    "alias": "CaseInterop",
     "nodes": [
       "CaseInterop"
     ],
@@ -59,6 +60,7 @@
     "isMain": false,
     "isLib": false,
     "name": "a_$b_C_$_$d",
+    "alias": "a_$b_C_$_$d",
     "nodes": [
       "a_$b_C_$_$d"
     ],

--- a/tool/test/expect/haxe_4_1_es6/web-release-closure-testinterop.json
+++ b/tool/test/expect/haxe_4_1_es6/web-release-closure-testinterop.json
@@ -37,6 +37,7 @@
     "isMain": false,
     "isLib": false,
     "name": "CaseInterop",
+    "alias": "CaseInterop",
     "nodes": [
       "CaseInterop"
     ],
@@ -58,6 +59,7 @@
     "isMain": false,
     "isLib": false,
     "name": "a_$b_C_$_$d",
+    "alias": "a_$b_C_$_$d",
     "nodes": [
       "a_$b_C_$_$d"
     ],

--- a/tool/test/expect/haxe_4_1_es6/web-release-test1.json
+++ b/tool/test/expect/haxe_4_1_es6/web-release-test1.json
@@ -33,6 +33,7 @@
     "isMain": false,
     "isLib": false,
     "name": "CaseA",
+    "alias": "CaseA",
     "nodes": [
       "CaseA"
     ],
@@ -49,6 +50,7 @@
     "isMain": false,
     "isLib": false,
     "name": "CaseB",
+    "alias": "CaseB",
     "nodes": [
       "CaseB",
       "DepB",

--- a/tool/test/expect/haxe_4_1_es6/web-release-test10.json
+++ b/tool/test/expect/haxe_4_1_es6/web-release-test10.json
@@ -27,6 +27,7 @@
     "isMain": false,
     "isLib": false,
     "name": "CaseE",
+    "alias": "CaseE",
     "nodes": [
       "CaseE"
     ],
@@ -46,6 +47,7 @@
     "isMain": false,
     "isLib": false,
     "name": "DepE",
+    "alias": "DepE",
     "nodes": [
       "DepE"
     ],

--- a/tool/test/expect/haxe_4_1_es6/web-release-test11.json
+++ b/tool/test/expect/haxe_4_1_es6/web-release-test11.json
@@ -24,6 +24,7 @@
     "isMain": false,
     "isLib": false,
     "name": "CaseF",
+    "alias": "CaseF",
     "nodes": [
       "CaseF",
       "haxe_Exception",

--- a/tool/test/expect/haxe_4_1_es6/web-release-test12.json
+++ b/tool/test/expect/haxe_4_1_es6/web-release-test12.json
@@ -26,6 +26,10 @@
   {
     "isMain": false,
     "isLib": true,
+    "libParams": [
+      "lib_",
+      "a_$b_C_$_$d"
+    ],
     "name": "lib",
     "nodes": [
       "a_$b_C_$_$d",

--- a/tool/test/expect/haxe_4_1_es6/web-release-test12.json
+++ b/tool/test/expect/haxe_4_1_es6/web-release-test12.json
@@ -31,6 +31,7 @@
       "a_$b_C_$_$d"
     ],
     "name": "lib",
+    "alias": "lib",
     "nodes": [
       "a_$b_C_$_$d",
       "lib_DepLib",

--- a/tool/test/expect/haxe_4_1_es6/web-release-test13.json
+++ b/tool/test/expect/haxe_4_1_es6/web-release-test13.json
@@ -24,6 +24,7 @@
     "isMain": false,
     "isLib": false,
     "name": "a_$b_Exposed",
+    "alias": "a_$b_Exposed",
     "nodes": [
       "a_$b_Exposed",
       "a_$b_SubExposed"

--- a/tool/test/expect/haxe_4_1_es6/web-release-test14.json
+++ b/tool/test/expect/haxe_4_1_es6/web-release-test14.json
@@ -20,6 +20,7 @@
     "isMain": false,
     "isLib": false,
     "name": "a_$b_Exposed",
+    "alias": "a_$b_Exposed",
     "nodes": [
       "a_$b_Exposed",
       "a_$b_SubExposed"

--- a/tool/test/expect/haxe_4_1_es6/web-release-test15.json
+++ b/tool/test/expect/haxe_4_1_es6/web-release-test15.json
@@ -24,6 +24,7 @@
     "isMain": false,
     "isLib": false,
     "name": "CaseG",
+    "alias": "CaseG",
     "nodes": [
       "CaseG"
     ],

--- a/tool/test/expect/haxe_4_1_es6/web-release-test2.json
+++ b/tool/test/expect/haxe_4_1_es6/web-release-test2.json
@@ -33,6 +33,7 @@
     "isMain": false,
     "isLib": false,
     "name": "CaseA",
+    "alias": "CaseA",
     "nodes": [
       "CaseA"
     ],
@@ -49,6 +50,7 @@
     "isMain": false,
     "isLib": false,
     "name": "CaseB",
+    "alias": "CaseB",
     "nodes": [
       "CaseB",
       "DepB",

--- a/tool/test/expect/haxe_4_1_es6/web-release-test3.json
+++ b/tool/test/expect/haxe_4_1_es6/web-release-test3.json
@@ -28,6 +28,7 @@
     "isMain": false,
     "isLib": false,
     "name": "CaseC",
+    "alias": "CaseC",
     "nodes": [
       "CaseC"
     ],
@@ -46,6 +47,7 @@
     "isMain": false,
     "isLib": false,
     "name": "DepC",
+    "alias": "DepC",
     "nodes": [
       "DepC",
       "DepSubC"
@@ -68,6 +70,7 @@
     "isMain": false,
     "isLib": false,
     "name": "SubC",
+    "alias": "SubC",
     "nodes": [
       "SubC"
     ],
@@ -84,6 +87,7 @@
     "isMain": false,
     "isLib": false,
     "name": "SubC2",
+    "alias": "SubC2",
     "nodes": [
       "SubC2"
     ],

--- a/tool/test/expect/haxe_4_1_es6/web-release-test4.json
+++ b/tool/test/expect/haxe_4_1_es6/web-release-test4.json
@@ -72,6 +72,9 @@
   {
     "isMain": false,
     "isLib": true,
+    "libParams": [
+      "lib_"
+    ],
     "name": "lib",
     "nodes": [
       "lib_DepLib",

--- a/tool/test/expect/haxe_4_1_es6/web-release-test4.json
+++ b/tool/test/expect/haxe_4_1_es6/web-release-test4.json
@@ -35,6 +35,7 @@
     "isMain": false,
     "isLib": false,
     "name": "CaseA",
+    "alias": "CaseA",
     "nodes": [
       "CaseA"
     ],
@@ -52,6 +53,7 @@
     "isMain": false,
     "isLib": false,
     "name": "CaseB",
+    "alias": "CaseB",
     "nodes": [
       "CaseB",
       "DepB",
@@ -76,6 +78,7 @@
       "lib_"
     ],
     "name": "lib",
+    "alias": "lib",
     "nodes": [
       "lib_DepLib",
       "lib_Lib",

--- a/tool/test/expect/haxe_4_1_es6/web-release-test5.json
+++ b/tool/test/expect/haxe_4_1_es6/web-release-test5.json
@@ -37,6 +37,7 @@
     "isMain": false,
     "isLib": false,
     "name": "CaseA",
+    "alias": "CaseA",
     "nodes": [
       "CaseA"
     ],
@@ -54,6 +55,7 @@
     "isMain": false,
     "isLib": false,
     "name": "CaseB",
+    "alias": "CaseB",
     "nodes": [
       "CaseB",
       "DepB",
@@ -79,6 +81,7 @@
       "a_$b_C_$_$d"
     ],
     "name": "lib",
+    "alias": "lib",
     "nodes": [
       "a_$b_C_$_$d",
       "lib_DepLib",

--- a/tool/test/expect/haxe_4_1_es6/web-release-test5.json
+++ b/tool/test/expect/haxe_4_1_es6/web-release-test5.json
@@ -74,6 +74,10 @@
   {
     "isMain": false,
     "isLib": true,
+    "libParams": [
+      "lib_",
+      "a_$b_C_$_$d"
+    ],
     "name": "lib",
     "nodes": [
       "a_$b_C_$_$d",

--- a/tool/test/expect/haxe_4_1_es6/web-release-test6.json
+++ b/tool/test/expect/haxe_4_1_es6/web-release-test6.json
@@ -26,6 +26,7 @@
     "isMain": false,
     "isLib": false,
     "name": "CaseA",
+    "alias": "CaseA",
     "nodes": [
       "CaseA",
       "DepAB",

--- a/tool/test/expect/haxe_4_1_es6/web-release-test7.json
+++ b/tool/test/expect/haxe_4_1_es6/web-release-test7.json
@@ -24,6 +24,7 @@
     "isMain": false,
     "isLib": false,
     "name": "CaseD",
+    "alias": "CaseD",
     "nodes": [
       "CaseD",
       "CycleD"

--- a/tool/test/expect/haxe_4_1_es6/web-release-test9.json
+++ b/tool/test/expect/haxe_4_1_es6/web-release-test9.json
@@ -24,6 +24,7 @@
     "isMain": false,
     "isLib": false,
     "name": "CaseD",
+    "alias": "CaseD",
     "nodes": [
       "CaseD"
     ],

--- a/tool/test/expect/haxe_4_1_es6/web-release-testinterop.json
+++ b/tool/test/expect/haxe_4_1_es6/web-release-testinterop.json
@@ -37,6 +37,7 @@
     "isMain": false,
     "isLib": false,
     "name": "CaseInterop",
+    "alias": "CaseInterop",
     "nodes": [
       "CaseInterop"
     ],
@@ -58,6 +59,7 @@
     "isMain": false,
     "isLib": false,
     "name": "a_$b_C_$_$d",
+    "alias": "a_$b_C_$_$d",
     "nodes": [
       "a_$b_C_$_$d"
     ],

--- a/tool/test/expect/haxe_4_1_es6/web-release-uglify-testinterop.json
+++ b/tool/test/expect/haxe_4_1_es6/web-release-uglify-testinterop.json
@@ -37,6 +37,7 @@
     "isMain": false,
     "isLib": false,
     "name": "CaseInterop",
+    "alias": "CaseInterop",
     "nodes": [
       "CaseInterop"
     ],
@@ -58,6 +59,7 @@
     "isMain": false,
     "isLib": false,
     "name": "a_$b_C_$_$d",
+    "alias": "a_$b_C_$_$d",
     "nodes": [
       "a_$b_C_$_$d"
     ],

--- a/tool/test/expect/haxe_4_es6/node-debug-test1.json
+++ b/tool/test/expect/haxe_4_es6/node-debug-test1.json
@@ -29,6 +29,7 @@
     "isMain": false,
     "isLib": false,
     "name": "CaseA",
+    "alias": "CaseA",
     "nodes": [
       "CaseA"
     ],
@@ -45,6 +46,7 @@
     "isMain": false,
     "isLib": false,
     "name": "CaseB",
+    "alias": "CaseB",
     "nodes": [
       "CaseB",
       "DepB"

--- a/tool/test/expect/haxe_4_es6/node-debug-test10.json
+++ b/tool/test/expect/haxe_4_es6/node-debug-test10.json
@@ -21,6 +21,7 @@
     "isMain": false,
     "isLib": false,
     "name": "CaseE",
+    "alias": "CaseE",
     "nodes": [
       "CaseE"
     ],
@@ -39,6 +40,7 @@
     "isMain": false,
     "isLib": false,
     "name": "DepE",
+    "alias": "DepE",
     "nodes": [
       "DepE"
     ],

--- a/tool/test/expect/haxe_4_es6/node-debug-test11.json
+++ b/tool/test/expect/haxe_4_es6/node-debug-test11.json
@@ -19,6 +19,7 @@
     "isMain": false,
     "isLib": false,
     "name": "CaseF",
+    "alias": "CaseF",
     "nodes": [
       "CaseF",
       "js__$Boot_HaxeError"

--- a/tool/test/expect/haxe_4_es6/node-debug-test12.json
+++ b/tool/test/expect/haxe_4_es6/node-debug-test12.json
@@ -24,6 +24,10 @@
   {
     "isMain": false,
     "isLib": true,
+    "libParams": [
+      "lib_",
+      "a_$b_C_$_$d"
+    ],
     "name": "lib",
     "nodes": [
       "a_$b_C_$_$d",

--- a/tool/test/expect/haxe_4_es6/node-debug-test12.json
+++ b/tool/test/expect/haxe_4_es6/node-debug-test12.json
@@ -29,6 +29,7 @@
       "a_$b_C_$_$d"
     ],
     "name": "lib",
+    "alias": "lib",
     "nodes": [
       "a_$b_C_$_$d",
       "lib_DepLib",

--- a/tool/test/expect/haxe_4_es6/node-debug-test13.json
+++ b/tool/test/expect/haxe_4_es6/node-debug-test13.json
@@ -19,6 +19,7 @@
     "isMain": false,
     "isLib": false,
     "name": "a_$b_Exposed",
+    "alias": "a_$b_Exposed",
     "nodes": [
       "a_$b_Exposed",
       "a_$b_SubExposed"

--- a/tool/test/expect/haxe_4_es6/node-debug-test14.json
+++ b/tool/test/expect/haxe_4_es6/node-debug-test14.json
@@ -16,6 +16,7 @@
     "isMain": false,
     "isLib": false,
     "name": "a_$b_Exposed",
+    "alias": "a_$b_Exposed",
     "nodes": [
       "a_$b_Exposed",
       "a_$b_SubExposed"

--- a/tool/test/expect/haxe_4_es6/node-debug-test15.json
+++ b/tool/test/expect/haxe_4_es6/node-debug-test15.json
@@ -21,6 +21,7 @@
     "isMain": false,
     "isLib": false,
     "name": "CaseG",
+    "alias": "CaseG",
     "nodes": [
       "CaseG"
     ],

--- a/tool/test/expect/haxe_4_es6/node-debug-test2.json
+++ b/tool/test/expect/haxe_4_es6/node-debug-test2.json
@@ -29,6 +29,7 @@
     "isMain": false,
     "isLib": false,
     "name": "CaseA",
+    "alias": "CaseA",
     "nodes": [
       "CaseA"
     ],
@@ -45,6 +46,7 @@
     "isMain": false,
     "isLib": false,
     "name": "CaseB",
+    "alias": "CaseB",
     "nodes": [
       "CaseB",
       "DepB"

--- a/tool/test/expect/haxe_4_es6/node-debug-test3.json
+++ b/tool/test/expect/haxe_4_es6/node-debug-test3.json
@@ -22,6 +22,7 @@
     "isMain": false,
     "isLib": false,
     "name": "CaseC",
+    "alias": "CaseC",
     "nodes": [
       "CaseC"
     ],
@@ -39,6 +40,7 @@
     "isMain": false,
     "isLib": false,
     "name": "DepC",
+    "alias": "DepC",
     "nodes": [
       "DepC",
       "DepSubC"
@@ -60,6 +62,7 @@
     "isMain": false,
     "isLib": false,
     "name": "SubC",
+    "alias": "SubC",
     "nodes": [
       "SubC"
     ],
@@ -76,6 +79,7 @@
     "isMain": false,
     "isLib": false,
     "name": "SubC2",
+    "alias": "SubC2",
     "nodes": [
       "SubC2"
     ],

--- a/tool/test/expect/haxe_4_es6/node-debug-test4.json
+++ b/tool/test/expect/haxe_4_es6/node-debug-test4.json
@@ -69,6 +69,9 @@
   {
     "isMain": false,
     "isLib": true,
+    "libParams": [
+      "lib_"
+    ],
     "name": "lib",
     "nodes": [
       "lib_DepLib",

--- a/tool/test/expect/haxe_4_es6/node-debug-test4.json
+++ b/tool/test/expect/haxe_4_es6/node-debug-test4.json
@@ -34,6 +34,7 @@
     "isMain": false,
     "isLib": false,
     "name": "CaseA",
+    "alias": "CaseA",
     "nodes": [
       "CaseA"
     ],
@@ -51,6 +52,7 @@
     "isMain": false,
     "isLib": false,
     "name": "CaseB",
+    "alias": "CaseB",
     "nodes": [
       "CaseB",
       "DepB"
@@ -73,6 +75,7 @@
       "lib_"
     ],
     "name": "lib",
+    "alias": "lib",
     "nodes": [
       "lib_DepLib",
       "lib_Lib",

--- a/tool/test/expect/haxe_4_es6/node-debug-test5.json
+++ b/tool/test/expect/haxe_4_es6/node-debug-test5.json
@@ -36,6 +36,7 @@
     "isMain": false,
     "isLib": false,
     "name": "CaseA",
+    "alias": "CaseA",
     "nodes": [
       "CaseA"
     ],
@@ -53,6 +54,7 @@
     "isMain": false,
     "isLib": false,
     "name": "CaseB",
+    "alias": "CaseB",
     "nodes": [
       "CaseB",
       "DepB"
@@ -76,6 +78,7 @@
       "a_$b_C_$_$d"
     ],
     "name": "lib",
+    "alias": "lib",
     "nodes": [
       "a_$b_C_$_$d",
       "lib_DepLib",

--- a/tool/test/expect/haxe_4_es6/node-debug-test5.json
+++ b/tool/test/expect/haxe_4_es6/node-debug-test5.json
@@ -71,6 +71,10 @@
   {
     "isMain": false,
     "isLib": true,
+    "libParams": [
+      "lib_",
+      "a_$b_C_$_$d"
+    ],
     "name": "lib",
     "nodes": [
       "a_$b_C_$_$d",

--- a/tool/test/expect/haxe_4_es6/node-debug-test6.json
+++ b/tool/test/expect/haxe_4_es6/node-debug-test6.json
@@ -21,6 +21,7 @@
     "isMain": false,
     "isLib": false,
     "name": "CaseA",
+    "alias": "CaseA",
     "nodes": [
       "CaseA",
       "DepAB",

--- a/tool/test/expect/haxe_4_es6/node-debug-test7.json
+++ b/tool/test/expect/haxe_4_es6/node-debug-test7.json
@@ -19,6 +19,7 @@
     "isMain": false,
     "isLib": false,
     "name": "CaseD",
+    "alias": "CaseD",
     "nodes": [
       "CaseD",
       "CycleD"

--- a/tool/test/expect/haxe_4_es6/node-debug-test9.json
+++ b/tool/test/expect/haxe_4_es6/node-debug-test9.json
@@ -19,6 +19,7 @@
     "isMain": false,
     "isLib": false,
     "name": "CaseD",
+    "alias": "CaseD",
     "nodes": [
       "CaseD"
     ],

--- a/tool/test/expect/haxe_4_es6/node-release-test1.json
+++ b/tool/test/expect/haxe_4_es6/node-release-test1.json
@@ -29,6 +29,7 @@
     "isMain": false,
     "isLib": false,
     "name": "CaseA",
+    "alias": "CaseA",
     "nodes": [
       "CaseA"
     ],
@@ -45,6 +46,7 @@
     "isMain": false,
     "isLib": false,
     "name": "CaseB",
+    "alias": "CaseB",
     "nodes": [
       "CaseB",
       "DepB",

--- a/tool/test/expect/haxe_4_es6/node-release-test10.json
+++ b/tool/test/expect/haxe_4_es6/node-release-test10.json
@@ -21,6 +21,7 @@
     "isMain": false,
     "isLib": false,
     "name": "CaseE",
+    "alias": "CaseE",
     "nodes": [
       "CaseE"
     ],
@@ -39,6 +40,7 @@
     "isMain": false,
     "isLib": false,
     "name": "DepE",
+    "alias": "DepE",
     "nodes": [
       "DepE"
     ],

--- a/tool/test/expect/haxe_4_es6/node-release-test11.json
+++ b/tool/test/expect/haxe_4_es6/node-release-test11.json
@@ -19,6 +19,7 @@
     "isMain": false,
     "isLib": false,
     "name": "CaseF",
+    "alias": "CaseF",
     "nodes": [
       "CaseF",
       "js__$Boot_HaxeError"

--- a/tool/test/expect/haxe_4_es6/node-release-test12.json
+++ b/tool/test/expect/haxe_4_es6/node-release-test12.json
@@ -24,6 +24,10 @@
   {
     "isMain": false,
     "isLib": true,
+    "libParams": [
+      "lib_",
+      "a_$b_C_$_$d"
+    ],
     "name": "lib",
     "nodes": [
       "a_$b_C_$_$d",

--- a/tool/test/expect/haxe_4_es6/node-release-test12.json
+++ b/tool/test/expect/haxe_4_es6/node-release-test12.json
@@ -29,6 +29,7 @@
       "a_$b_C_$_$d"
     ],
     "name": "lib",
+    "alias": "lib",
     "nodes": [
       "a_$b_C_$_$d",
       "lib_DepLib",

--- a/tool/test/expect/haxe_4_es6/node-release-test13.json
+++ b/tool/test/expect/haxe_4_es6/node-release-test13.json
@@ -19,6 +19,7 @@
     "isMain": false,
     "isLib": false,
     "name": "a_$b_Exposed",
+    "alias": "a_$b_Exposed",
     "nodes": [
       "a_$b_Exposed",
       "a_$b_SubExposed"

--- a/tool/test/expect/haxe_4_es6/node-release-test14.json
+++ b/tool/test/expect/haxe_4_es6/node-release-test14.json
@@ -16,6 +16,7 @@
     "isMain": false,
     "isLib": false,
     "name": "a_$b_Exposed",
+    "alias": "a_$b_Exposed",
     "nodes": [
       "a_$b_Exposed",
       "a_$b_SubExposed"

--- a/tool/test/expect/haxe_4_es6/node-release-test15.json
+++ b/tool/test/expect/haxe_4_es6/node-release-test15.json
@@ -21,6 +21,7 @@
     "isMain": false,
     "isLib": false,
     "name": "CaseG",
+    "alias": "CaseG",
     "nodes": [
       "CaseG"
     ],

--- a/tool/test/expect/haxe_4_es6/node-release-test2.json
+++ b/tool/test/expect/haxe_4_es6/node-release-test2.json
@@ -29,6 +29,7 @@
     "isMain": false,
     "isLib": false,
     "name": "CaseA",
+    "alias": "CaseA",
     "nodes": [
       "CaseA"
     ],
@@ -45,6 +46,7 @@
     "isMain": false,
     "isLib": false,
     "name": "CaseB",
+    "alias": "CaseB",
     "nodes": [
       "CaseB",
       "DepB",

--- a/tool/test/expect/haxe_4_es6/node-release-test3.json
+++ b/tool/test/expect/haxe_4_es6/node-release-test3.json
@@ -22,6 +22,7 @@
     "isMain": false,
     "isLib": false,
     "name": "CaseC",
+    "alias": "CaseC",
     "nodes": [
       "CaseC"
     ],
@@ -39,6 +40,7 @@
     "isMain": false,
     "isLib": false,
     "name": "DepC",
+    "alias": "DepC",
     "nodes": [
       "DepC",
       "DepSubC"
@@ -60,6 +62,7 @@
     "isMain": false,
     "isLib": false,
     "name": "SubC",
+    "alias": "SubC",
     "nodes": [
       "SubC"
     ],
@@ -76,6 +79,7 @@
     "isMain": false,
     "isLib": false,
     "name": "SubC2",
+    "alias": "SubC2",
     "nodes": [
       "SubC2"
     ],

--- a/tool/test/expect/haxe_4_es6/node-release-test4.json
+++ b/tool/test/expect/haxe_4_es6/node-release-test4.json
@@ -34,6 +34,7 @@
     "isMain": false,
     "isLib": false,
     "name": "CaseA",
+    "alias": "CaseA",
     "nodes": [
       "CaseA"
     ],
@@ -51,6 +52,7 @@
     "isMain": false,
     "isLib": false,
     "name": "CaseB",
+    "alias": "CaseB",
     "nodes": [
       "CaseB",
       "DepB",
@@ -75,6 +77,7 @@
       "lib_"
     ],
     "name": "lib",
+    "alias": "lib",
     "nodes": [
       "lib_DepLib",
       "lib_Lib",

--- a/tool/test/expect/haxe_4_es6/node-release-test4.json
+++ b/tool/test/expect/haxe_4_es6/node-release-test4.json
@@ -71,6 +71,9 @@
   {
     "isMain": false,
     "isLib": true,
+    "libParams": [
+      "lib_"
+    ],
     "name": "lib",
     "nodes": [
       "lib_DepLib",

--- a/tool/test/expect/haxe_4_es6/node-release-test5.json
+++ b/tool/test/expect/haxe_4_es6/node-release-test5.json
@@ -36,6 +36,7 @@
     "isMain": false,
     "isLib": false,
     "name": "CaseA",
+    "alias": "CaseA",
     "nodes": [
       "CaseA"
     ],
@@ -53,6 +54,7 @@
     "isMain": false,
     "isLib": false,
     "name": "CaseB",
+    "alias": "CaseB",
     "nodes": [
       "CaseB",
       "DepB",
@@ -78,6 +80,7 @@
       "a_$b_C_$_$d"
     ],
     "name": "lib",
+    "alias": "lib",
     "nodes": [
       "a_$b_C_$_$d",
       "lib_DepLib",

--- a/tool/test/expect/haxe_4_es6/node-release-test5.json
+++ b/tool/test/expect/haxe_4_es6/node-release-test5.json
@@ -73,6 +73,10 @@
   {
     "isMain": false,
     "isLib": true,
+    "libParams": [
+      "lib_",
+      "a_$b_C_$_$d"
+    ],
     "name": "lib",
     "nodes": [
       "a_$b_C_$_$d",

--- a/tool/test/expect/haxe_4_es6/node-release-test6.json
+++ b/tool/test/expect/haxe_4_es6/node-release-test6.json
@@ -21,6 +21,7 @@
     "isMain": false,
     "isLib": false,
     "name": "CaseA",
+    "alias": "CaseA",
     "nodes": [
       "CaseA",
       "DepAB",

--- a/tool/test/expect/haxe_4_es6/node-release-test7.json
+++ b/tool/test/expect/haxe_4_es6/node-release-test7.json
@@ -19,6 +19,7 @@
     "isMain": false,
     "isLib": false,
     "name": "CaseD",
+    "alias": "CaseD",
     "nodes": [
       "CaseD",
       "CycleD"

--- a/tool/test/expect/haxe_4_es6/node-release-test9.json
+++ b/tool/test/expect/haxe_4_es6/node-release-test9.json
@@ -19,6 +19,7 @@
     "isMain": false,
     "isLib": false,
     "name": "CaseD",
+    "alias": "CaseD",
     "nodes": [
       "CaseD"
     ],

--- a/tool/test/expect/haxe_4_es6/web-debug-closure-testinterop.json
+++ b/tool/test/expect/haxe_4_es6/web-debug-closure-testinterop.json
@@ -36,6 +36,7 @@
     "isMain": false,
     "isLib": false,
     "name": "CaseInterop",
+    "alias": "CaseInterop",
     "nodes": [
       "CaseInterop"
     ],
@@ -57,6 +58,7 @@
     "isMain": false,
     "isLib": false,
     "name": "a_$b_C_$_$d",
+    "alias": "a_$b_C_$_$d",
     "nodes": [
       "a_$b_C_$_$d"
     ],

--- a/tool/test/expect/haxe_4_es6/web-debug-test1.json
+++ b/tool/test/expect/haxe_4_es6/web-debug-test1.json
@@ -35,6 +35,7 @@
     "isMain": false,
     "isLib": false,
     "name": "CaseA",
+    "alias": "CaseA",
     "nodes": [
       "CaseA"
     ],
@@ -51,6 +52,7 @@
     "isMain": false,
     "isLib": false,
     "name": "CaseB",
+    "alias": "CaseB",
     "nodes": [
       "CaseB",
       "DepB"

--- a/tool/test/expect/haxe_4_es6/web-debug-test10.json
+++ b/tool/test/expect/haxe_4_es6/web-debug-test10.json
@@ -30,6 +30,7 @@
     "isMain": false,
     "isLib": false,
     "name": "CaseE",
+    "alias": "CaseE",
     "nodes": [
       "CaseE"
     ],
@@ -49,6 +50,7 @@
     "isMain": false,
     "isLib": false,
     "name": "DepE",
+    "alias": "DepE",
     "nodes": [
       "DepE"
     ],

--- a/tool/test/expect/haxe_4_es6/web-debug-test11.json
+++ b/tool/test/expect/haxe_4_es6/web-debug-test11.json
@@ -28,6 +28,7 @@
     "isMain": false,
     "isLib": false,
     "name": "CaseF",
+    "alias": "CaseF",
     "nodes": [
       "CaseF"
     ],

--- a/tool/test/expect/haxe_4_es6/web-debug-test12.json
+++ b/tool/test/expect/haxe_4_es6/web-debug-test12.json
@@ -30,6 +30,7 @@
       "a_$b_C_$_$d"
     ],
     "name": "lib",
+    "alias": "lib",
     "nodes": [
       "a_$b_C_$_$d",
       "lib_DepLib",

--- a/tool/test/expect/haxe_4_es6/web-debug-test12.json
+++ b/tool/test/expect/haxe_4_es6/web-debug-test12.json
@@ -25,6 +25,10 @@
   {
     "isMain": false,
     "isLib": true,
+    "libParams": [
+      "lib_",
+      "a_$b_C_$_$d"
+    ],
     "name": "lib",
     "nodes": [
       "a_$b_C_$_$d",

--- a/tool/test/expect/haxe_4_es6/web-debug-test13.json
+++ b/tool/test/expect/haxe_4_es6/web-debug-test13.json
@@ -27,6 +27,7 @@
     "isMain": false,
     "isLib": false,
     "name": "a_$b_Exposed",
+    "alias": "a_$b_Exposed",
     "nodes": [
       "a_$b_Exposed",
       "a_$b_SubExposed"

--- a/tool/test/expect/haxe_4_es6/web-debug-test14.json
+++ b/tool/test/expect/haxe_4_es6/web-debug-test14.json
@@ -23,6 +23,7 @@
     "isMain": false,
     "isLib": false,
     "name": "a_$b_Exposed",
+    "alias": "a_$b_Exposed",
     "nodes": [
       "a_$b_Exposed",
       "a_$b_SubExposed"

--- a/tool/test/expect/haxe_4_es6/web-debug-test15.json
+++ b/tool/test/expect/haxe_4_es6/web-debug-test15.json
@@ -28,6 +28,7 @@
     "isMain": false,
     "isLib": false,
     "name": "CaseG",
+    "alias": "CaseG",
     "nodes": [
       "CaseG"
     ],

--- a/tool/test/expect/haxe_4_es6/web-debug-test2.json
+++ b/tool/test/expect/haxe_4_es6/web-debug-test2.json
@@ -35,6 +35,7 @@
     "isMain": false,
     "isLib": false,
     "name": "CaseA",
+    "alias": "CaseA",
     "nodes": [
       "CaseA"
     ],
@@ -51,6 +52,7 @@
     "isMain": false,
     "isLib": false,
     "name": "CaseB",
+    "alias": "CaseB",
     "nodes": [
       "CaseB",
       "DepB"

--- a/tool/test/expect/haxe_4_es6/web-debug-test3.json
+++ b/tool/test/expect/haxe_4_es6/web-debug-test3.json
@@ -31,6 +31,7 @@
     "isMain": false,
     "isLib": false,
     "name": "CaseC",
+    "alias": "CaseC",
     "nodes": [
       "CaseC"
     ],
@@ -49,6 +50,7 @@
     "isMain": false,
     "isLib": false,
     "name": "DepC",
+    "alias": "DepC",
     "nodes": [
       "DepC",
       "DepSubC"
@@ -71,6 +73,7 @@
     "isMain": false,
     "isLib": false,
     "name": "SubC",
+    "alias": "SubC",
     "nodes": [
       "SubC"
     ],
@@ -87,6 +90,7 @@
     "isMain": false,
     "isLib": false,
     "name": "SubC2",
+    "alias": "SubC2",
     "nodes": [
       "SubC2"
     ],

--- a/tool/test/expect/haxe_4_es6/web-debug-test4.json
+++ b/tool/test/expect/haxe_4_es6/web-debug-test4.json
@@ -72,6 +72,9 @@
   {
     "isMain": false,
     "isLib": true,
+    "libParams": [
+      "lib_"
+    ],
     "name": "lib",
     "nodes": [
       "lib_DepLib",

--- a/tool/test/expect/haxe_4_es6/web-debug-test4.json
+++ b/tool/test/expect/haxe_4_es6/web-debug-test4.json
@@ -37,6 +37,7 @@
     "isMain": false,
     "isLib": false,
     "name": "CaseA",
+    "alias": "CaseA",
     "nodes": [
       "CaseA"
     ],
@@ -54,6 +55,7 @@
     "isMain": false,
     "isLib": false,
     "name": "CaseB",
+    "alias": "CaseB",
     "nodes": [
       "CaseB",
       "DepB"
@@ -76,6 +78,7 @@
       "lib_"
     ],
     "name": "lib",
+    "alias": "lib",
     "nodes": [
       "lib_DepLib",
       "lib_Lib",

--- a/tool/test/expect/haxe_4_es6/web-debug-test5.json
+++ b/tool/test/expect/haxe_4_es6/web-debug-test5.json
@@ -39,6 +39,7 @@
     "isMain": false,
     "isLib": false,
     "name": "CaseA",
+    "alias": "CaseA",
     "nodes": [
       "CaseA"
     ],
@@ -56,6 +57,7 @@
     "isMain": false,
     "isLib": false,
     "name": "CaseB",
+    "alias": "CaseB",
     "nodes": [
       "CaseB",
       "DepB"
@@ -79,6 +81,7 @@
       "a_$b_C_$_$d"
     ],
     "name": "lib",
+    "alias": "lib",
     "nodes": [
       "a_$b_C_$_$d",
       "lib_DepLib",

--- a/tool/test/expect/haxe_4_es6/web-debug-test5.json
+++ b/tool/test/expect/haxe_4_es6/web-debug-test5.json
@@ -74,6 +74,10 @@
   {
     "isMain": false,
     "isLib": true,
+    "libParams": [
+      "lib_",
+      "a_$b_C_$_$d"
+    ],
     "name": "lib",
     "nodes": [
       "a_$b_C_$_$d",

--- a/tool/test/expect/haxe_4_es6/web-debug-test6.json
+++ b/tool/test/expect/haxe_4_es6/web-debug-test6.json
@@ -29,6 +29,7 @@
     "isMain": false,
     "isLib": false,
     "name": "CaseA",
+    "alias": "CaseA",
     "nodes": [
       "CaseA",
       "DepAB",

--- a/tool/test/expect/haxe_4_es6/web-debug-test7.json
+++ b/tool/test/expect/haxe_4_es6/web-debug-test7.json
@@ -27,6 +27,7 @@
     "isMain": false,
     "isLib": false,
     "name": "CaseD",
+    "alias": "CaseD",
     "nodes": [
       "CaseD",
       "CycleD"

--- a/tool/test/expect/haxe_4_es6/web-debug-test9.json
+++ b/tool/test/expect/haxe_4_es6/web-debug-test9.json
@@ -27,6 +27,7 @@
     "isMain": false,
     "isLib": false,
     "name": "CaseD",
+    "alias": "CaseD",
     "nodes": [
       "CaseD"
     ],

--- a/tool/test/expect/haxe_4_es6/web-debug-testinterop.json
+++ b/tool/test/expect/haxe_4_es6/web-debug-testinterop.json
@@ -36,6 +36,7 @@
     "isMain": false,
     "isLib": false,
     "name": "CaseInterop",
+    "alias": "CaseInterop",
     "nodes": [
       "CaseInterop"
     ],
@@ -57,6 +58,7 @@
     "isMain": false,
     "isLib": false,
     "name": "a_$b_C_$_$d",
+    "alias": "a_$b_C_$_$d",
     "nodes": [
       "a_$b_C_$_$d"
     ],

--- a/tool/test/expect/haxe_4_es6/web-debug-uglify-testinterop.json
+++ b/tool/test/expect/haxe_4_es6/web-debug-uglify-testinterop.json
@@ -36,6 +36,7 @@
     "isMain": false,
     "isLib": false,
     "name": "CaseInterop",
+    "alias": "CaseInterop",
     "nodes": [
       "CaseInterop"
     ],
@@ -57,6 +58,7 @@
     "isMain": false,
     "isLib": false,
     "name": "a_$b_C_$_$d",
+    "alias": "a_$b_C_$_$d",
     "nodes": [
       "a_$b_C_$_$d"
     ],

--- a/tool/test/expect/haxe_4_es6/web-release-closure-testinterop.json
+++ b/tool/test/expect/haxe_4_es6/web-release-closure-testinterop.json
@@ -35,6 +35,7 @@
     "isMain": false,
     "isLib": false,
     "name": "CaseInterop",
+    "alias": "CaseInterop",
     "nodes": [
       "CaseInterop"
     ],
@@ -56,6 +57,7 @@
     "isMain": false,
     "isLib": false,
     "name": "a_$b_C_$_$d",
+    "alias": "a_$b_C_$_$d",
     "nodes": [
       "a_$b_C_$_$d"
     ],

--- a/tool/test/expect/haxe_4_es6/web-release-test1.json
+++ b/tool/test/expect/haxe_4_es6/web-release-test1.json
@@ -33,6 +33,7 @@
     "isMain": false,
     "isLib": false,
     "name": "CaseA",
+    "alias": "CaseA",
     "nodes": [
       "CaseA"
     ],
@@ -49,6 +50,7 @@
     "isMain": false,
     "isLib": false,
     "name": "CaseB",
+    "alias": "CaseB",
     "nodes": [
       "CaseB",
       "DepB",

--- a/tool/test/expect/haxe_4_es6/web-release-test10.json
+++ b/tool/test/expect/haxe_4_es6/web-release-test10.json
@@ -26,6 +26,7 @@
     "isMain": false,
     "isLib": false,
     "name": "CaseE",
+    "alias": "CaseE",
     "nodes": [
       "CaseE"
     ],
@@ -45,6 +46,7 @@
     "isMain": false,
     "isLib": false,
     "name": "DepE",
+    "alias": "DepE",
     "nodes": [
       "DepE"
     ],

--- a/tool/test/expect/haxe_4_es6/web-release-test11.json
+++ b/tool/test/expect/haxe_4_es6/web-release-test11.json
@@ -23,6 +23,7 @@
     "isMain": false,
     "isLib": false,
     "name": "CaseF",
+    "alias": "CaseF",
     "nodes": [
       "CaseF",
       "js__$Boot_HaxeError"

--- a/tool/test/expect/haxe_4_es6/web-release-test12.json
+++ b/tool/test/expect/haxe_4_es6/web-release-test12.json
@@ -30,6 +30,7 @@
       "a_$b_C_$_$d"
     ],
     "name": "lib",
+    "alias": "lib",
     "nodes": [
       "a_$b_C_$_$d",
       "lib_DepLib",

--- a/tool/test/expect/haxe_4_es6/web-release-test12.json
+++ b/tool/test/expect/haxe_4_es6/web-release-test12.json
@@ -25,6 +25,10 @@
   {
     "isMain": false,
     "isLib": true,
+    "libParams": [
+      "lib_",
+      "a_$b_C_$_$d"
+    ],
     "name": "lib",
     "nodes": [
       "a_$b_C_$_$d",

--- a/tool/test/expect/haxe_4_es6/web-release-test13.json
+++ b/tool/test/expect/haxe_4_es6/web-release-test13.json
@@ -23,6 +23,7 @@
     "isMain": false,
     "isLib": false,
     "name": "a_$b_Exposed",
+    "alias": "a_$b_Exposed",
     "nodes": [
       "a_$b_Exposed",
       "a_$b_SubExposed"

--- a/tool/test/expect/haxe_4_es6/web-release-test14.json
+++ b/tool/test/expect/haxe_4_es6/web-release-test14.json
@@ -19,6 +19,7 @@
     "isMain": false,
     "isLib": false,
     "name": "a_$b_Exposed",
+    "alias": "a_$b_Exposed",
     "nodes": [
       "a_$b_Exposed",
       "a_$b_SubExposed"

--- a/tool/test/expect/haxe_4_es6/web-release-test15.json
+++ b/tool/test/expect/haxe_4_es6/web-release-test15.json
@@ -24,6 +24,7 @@
     "isMain": false,
     "isLib": false,
     "name": "CaseG",
+    "alias": "CaseG",
     "nodes": [
       "CaseG"
     ],

--- a/tool/test/expect/haxe_4_es6/web-release-test2.json
+++ b/tool/test/expect/haxe_4_es6/web-release-test2.json
@@ -33,6 +33,7 @@
     "isMain": false,
     "isLib": false,
     "name": "CaseA",
+    "alias": "CaseA",
     "nodes": [
       "CaseA"
     ],
@@ -49,6 +50,7 @@
     "isMain": false,
     "isLib": false,
     "name": "CaseB",
+    "alias": "CaseB",
     "nodes": [
       "CaseB",
       "DepB",

--- a/tool/test/expect/haxe_4_es6/web-release-test3.json
+++ b/tool/test/expect/haxe_4_es6/web-release-test3.json
@@ -27,6 +27,7 @@
     "isMain": false,
     "isLib": false,
     "name": "CaseC",
+    "alias": "CaseC",
     "nodes": [
       "CaseC"
     ],
@@ -45,6 +46,7 @@
     "isMain": false,
     "isLib": false,
     "name": "DepC",
+    "alias": "DepC",
     "nodes": [
       "DepC",
       "DepSubC"
@@ -67,6 +69,7 @@
     "isMain": false,
     "isLib": false,
     "name": "SubC",
+    "alias": "SubC",
     "nodes": [
       "SubC"
     ],
@@ -83,6 +86,7 @@
     "isMain": false,
     "isLib": false,
     "name": "SubC2",
+    "alias": "SubC2",
     "nodes": [
       "SubC2"
     ],

--- a/tool/test/expect/haxe_4_es6/web-release-test4.json
+++ b/tool/test/expect/haxe_4_es6/web-release-test4.json
@@ -72,6 +72,9 @@
   {
     "isMain": false,
     "isLib": true,
+    "libParams": [
+      "lib_"
+    ],
     "name": "lib",
     "nodes": [
       "lib_DepLib",

--- a/tool/test/expect/haxe_4_es6/web-release-test4.json
+++ b/tool/test/expect/haxe_4_es6/web-release-test4.json
@@ -35,6 +35,7 @@
     "isMain": false,
     "isLib": false,
     "name": "CaseA",
+    "alias": "CaseA",
     "nodes": [
       "CaseA"
     ],
@@ -52,6 +53,7 @@
     "isMain": false,
     "isLib": false,
     "name": "CaseB",
+    "alias": "CaseB",
     "nodes": [
       "CaseB",
       "DepB",
@@ -76,6 +78,7 @@
       "lib_"
     ],
     "name": "lib",
+    "alias": "lib",
     "nodes": [
       "lib_DepLib",
       "lib_Lib",

--- a/tool/test/expect/haxe_4_es6/web-release-test5.json
+++ b/tool/test/expect/haxe_4_es6/web-release-test5.json
@@ -37,6 +37,7 @@
     "isMain": false,
     "isLib": false,
     "name": "CaseA",
+    "alias": "CaseA",
     "nodes": [
       "CaseA"
     ],
@@ -54,6 +55,7 @@
     "isMain": false,
     "isLib": false,
     "name": "CaseB",
+    "alias": "CaseB",
     "nodes": [
       "CaseB",
       "DepB",
@@ -79,6 +81,7 @@
       "a_$b_C_$_$d"
     ],
     "name": "lib",
+    "alias": "lib",
     "nodes": [
       "a_$b_C_$_$d",
       "lib_DepLib",

--- a/tool/test/expect/haxe_4_es6/web-release-test5.json
+++ b/tool/test/expect/haxe_4_es6/web-release-test5.json
@@ -74,6 +74,10 @@
   {
     "isMain": false,
     "isLib": true,
+    "libParams": [
+      "lib_",
+      "a_$b_C_$_$d"
+    ],
     "name": "lib",
     "nodes": [
       "a_$b_C_$_$d",

--- a/tool/test/expect/haxe_4_es6/web-release-test6.json
+++ b/tool/test/expect/haxe_4_es6/web-release-test6.json
@@ -25,6 +25,7 @@
     "isMain": false,
     "isLib": false,
     "name": "CaseA",
+    "alias": "CaseA",
     "nodes": [
       "CaseA",
       "DepAB",

--- a/tool/test/expect/haxe_4_es6/web-release-test7.json
+++ b/tool/test/expect/haxe_4_es6/web-release-test7.json
@@ -23,6 +23,7 @@
     "isMain": false,
     "isLib": false,
     "name": "CaseD",
+    "alias": "CaseD",
     "nodes": [
       "CaseD",
       "CycleD"

--- a/tool/test/expect/haxe_4_es6/web-release-test9.json
+++ b/tool/test/expect/haxe_4_es6/web-release-test9.json
@@ -23,6 +23,7 @@
     "isMain": false,
     "isLib": false,
     "name": "CaseD",
+    "alias": "CaseD",
     "nodes": [
       "CaseD"
     ],

--- a/tool/test/expect/haxe_4_es6/web-release-testinterop.json
+++ b/tool/test/expect/haxe_4_es6/web-release-testinterop.json
@@ -35,6 +35,7 @@
     "isMain": false,
     "isLib": false,
     "name": "CaseInterop",
+    "alias": "CaseInterop",
     "nodes": [
       "CaseInterop"
     ],
@@ -56,6 +57,7 @@
     "isMain": false,
     "isLib": false,
     "name": "a_$b_C_$_$d",
+    "alias": "a_$b_C_$_$d",
     "nodes": [
       "a_$b_C_$_$d"
     ],

--- a/tool/test/expect/haxe_4_es6/web-release-uglify-testinterop.json
+++ b/tool/test/expect/haxe_4_es6/web-release-uglify-testinterop.json
@@ -35,6 +35,7 @@
     "isMain": false,
     "isLib": false,
     "name": "CaseInterop",
+    "alias": "CaseInterop",
     "nodes": [
       "CaseInterop"
     ],
@@ -56,6 +57,7 @@
     "isMain": false,
     "isLib": false,
     "name": "a_$b_C_$_$d",
+    "alias": "a_$b_C_$_$d",
     "nodes": [
       "a_$b_C_$_$d"
     ],

--- a/tool/test/src/Test15.hx
+++ b/tool/test/src/Test15.hx
@@ -5,7 +5,7 @@ class Test15 {
 	static function main() {
 		trace('Suite Test15');
 		var a = [1,2,3];
-        Lambda.foreach(a, function(it) { trace(it); return true; });
+		Lambda.foreach(a, function(it) { trace(it); return true; });
 
 		Bundle.load(CaseG).then(function(_) {
 			new CaseG();

--- a/tool/test/validate.js
+++ b/tool/test/validate.js
@@ -8,8 +8,8 @@ const valid = args[3];
 
 const resultRaw = String(fs.readFileSync(result));
 
-// if valid is missing, save result
-if (!fs.existsSync(valid)) {
+// if valid is missing (or we want to update), save result
+if (process.env.UPDATE_EXPECT === 'true' || !fs.existsSync(valid)) {
 	console.log('[Update]', valid, 'from', result);
 	fs.writeFileSync(valid, resultRaw);
 }


### PR DESCRIPTION
Added optional bundle name argument to `Bundle.load(classRef, ?bundleName)`.

Fixes #102
